### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
             pyversion: '3.7'
           - name: Linux py38
             pyversion: '3.8'
+          - name: Linux py39
+            pyversion: '3.9'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install poetry
         run: |
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-            echo "::add-path::$HOME/.poetry/bin"
+            echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
             poetry install

--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -258,6 +258,10 @@ class ObservableDict(dict):
 
 if sys.version_info >= (3, 8, 0):
     ObservableDict._READERS.add("__reversed__")
+if sys.version_info >= (3, 9, 0):
+    ObservableDict._READERS.add("__or__")
+    ObservableDict._READERS.add("__ror__")
+    ObservableDict._WRITERS.add("__ior__")
 ObservableDict = make_observable(ObservableDict)
 
 

--- a/scripts.py
+++ b/scripts.py
@@ -2,11 +2,11 @@ from subprocess import CalledProcessError, run
 import sys
 
 
-def test():
+def test(args):
     try:
         run(["flake8"], check=True)
         run(
-            ["pytest", "--cov=observ", "--cov-report=term-missing"], check=True,
+            ["pytest", "--cov=observ", "--cov-report=term-missing"] + args, check=True,
         )
     except CalledProcessError:
         sys.exit(1)
@@ -15,7 +15,7 @@ def test():
 def main():
     cmd = sys.argv[0]
     if cmd == "test":
-        test()
+        test(sys.argv[1:])
     else:
         sys.exit(1)
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -39,6 +39,7 @@ EXCLUDED = {
     "__reduce_ex__",
     "__hash__",
     "_orphaned_keydeps",
+    "__class_getitem__",
 } | WRAPATTRS
 
 
@@ -186,6 +187,7 @@ def test_set_depend():
 def test_dict_notify():
     args = {
         "update": ({5: 6},),
+        "__ior__": ({5: 6},),
     }
     for name in ObservableDict._WRITERS:
         coll = ObservableDict({2: 3})
@@ -237,6 +239,9 @@ def test_dict_depend():
         "__sizeof__": (),
         "__str__": (),
         "__reversed__": (),
+        "__ror__": ({},),
+        "__or__": ({},),
+        "__ior__": ({},),
     }
     for name in ObservableDict._READERS:
         Dep.stack.append(None)


### PR DESCRIPTION
Dicts have gained `__or__`, `__ror__` and `__ior__` functions.
Those functions are now wrapped as well.

There is also the new `__class_getitem__` function which is now
part of the excluded functions.

Bonus: you can now pass some arguments to `pytest` through the poetry `scripts.py`.