### PR TITLE
Add qt example

### DIFF
--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -31,7 +31,7 @@ class Display(QWidget):
                 return "Please click the button below"
             return f"Clicked {state['clicked']} times!"
 
-        self.watcher = watch(lambda: label_text(), self.update_label, immediate=True)
+        self.watcher = watch(label_text, self.update_label, immediate=True)
 
     def update_label(self, old_value, new_value):
         self.label.setText(new_value)

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -1,0 +1,82 @@
+"""
+PyQt example that shows how to utilize observ
+in combination with Qt.
+
+State is passed to the widgets. One of the widgets
+adjusts the state while the other watches the state
+and updates the label whenever a computed property
+based on the state changes.
+"""
+
+from observ import computed, observe, watch
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class Display(QWidget):
+    def __init__(self, state, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.state = state
+
+        self.label = QLabel()
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.label)
+
+        self.setLayout(layout)
+
+        @computed
+        def label_text():
+            if state["clicked"] == 0:
+                return "Please click the button below"
+            return f"Clicked {state['clicked']} times!"
+
+        self.watcher = watch(lambda: label_text(), self.update_label)
+        self.watcher.update()
+
+    def update_label(self, old_value, new_value):
+        self.label.setText(new_value)
+
+
+class Controls(QWidget):
+    def __init__(self, state, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.state = state
+
+        self.button = QPushButton("Click")
+        self.reset = QPushButton("Reset")
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.button)
+        layout.addWidget(self.reset)
+
+        self.setLayout(layout)
+
+        self.button.clicked.connect(self.on_button_clicked)
+        self.reset.clicked.connect(self.on_reset_clicked)
+
+    def on_button_clicked(self):
+        self.state["clicked"] += 1
+
+    def on_reset_clicked(self):
+        self.state["clicked"] = 0
+
+
+if __name__ == "__main__":
+    # Define some state
+    state = observe({"clicked": 0})
+
+    app = QApplication([])
+
+    # Create layout and pass state to widgets
+    layout = QVBoxLayout()
+    layout.addWidget(Display(state))
+    layout.addWidget(Controls(state))
+
+    widget = QWidget()
+    widget.setLayout(layout)
+    widget.show()
+    widget.setWindowTitle("Clicked?")
+
+    app.exec_()

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -31,8 +31,7 @@ class Display(QWidget):
                 return "Please click the button below"
             return f"Clicked {state['clicked']} times!"
 
-        self.watcher = watch(lambda: label_text(), self.update_label)
-        self.watcher.update()
+        self.watcher = watch(lambda: label_text(), self.update_label, immediate=True)
 
     def update_label(self, old_value, new_value):
         self.label.setText(new_value)

--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -421,5 +421,6 @@ def computed(fn):
 def watch(fn, callback, deep=False, immediate=False):
     watcher = Watcher(fn, lazy=False, deep=deep, callback=callback)
     if immediate:
+        watcher.dirty = True
         watcher.evaluate()
     return watcher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8-import-order = "^0.18.1"
 flake8-print = "^3.1.4"
 pytest = "^5.4.3"
 pytest-cov = "^2.10.0"
+# PyQt5 = "^5.15.4"  # needed for PyQt example
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
I took the liberty of constructing an example that shows how `observ` can be combined with PyQt. Hope you like it.

One thing that I noticed is that passing `immediate=True` to the `watch` function didn't trigger the watcher, because the watcher is not 'dirty'. And that is because the `dirty` flag is set to the value of `lazy`, which defaults to `False` in the `watch` function. 
Hence I added the line in the `watch` function to ensure that the watcher is evaluated when passing `immediate=True`. Small problem is that `old_value` and `new_value` in the callback will be the same value on first evaluation...

I've also added a line with PyQt in pyproject.toml to easily run the Qt example, but I've left it commented out, because I don't think it is really a 'dev' dependency.