### PR TITLE
Silence teardown

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -19,7 +19,10 @@ class Dep:
         self._subs.add(sub)
 
     def remove_sub(self, sub: "Watcher") -> None:
-        self._subs.remove(sub)
+        try:
+            self._subs.remove(sub)
+        except KeyError:
+            pass  # this can happen at shutdown of the app, which is fine
 
     def depend(self) -> None:
         if self.stack:


### PR DESCRIPTION
When running the example merged as part of #20 I got the following errors at shutdown:

```
C:\Users\korij_000\dev\observ (master -> origin)
λ poetry run python examples\observe_qt.py
Exception ignored in: <bound method Watcher.__del__ of <observ.Watcher object at 0x000002285D456E10>>
Traceback (most recent call last):
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 114, in __del__
    self.teardown()
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 111, in teardown
    dep.remove_sub(self)
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 22, in remove_sub
    self._subs.remove(sub)
  File "C:\Users\korij_000\AppData\Local\Programs\Python\Python36\lib\_weakrefset.py", line 109, in remove
    self.data.remove(ref(item))
KeyError: (<weakref at 0x000002285D440F98; to 'Watcher' at 0x000002285D456E10>,)
Exception ignored in: <bound method Watcher.__del__ of <observ.Watcher object at 0x000002285D456CC0>>
Traceback (most recent call last):
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 114, in __del__
    self.teardown()
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 111, in teardown
    dep.remove_sub(self)
  File "C:\Users\korij_000\dev\observ\observ\__init__.py", line 22, in remove_sub
    self._subs.remove(sub)
  File "C:\Users\korij_000\AppData\Local\Programs\Python\Python36\lib\_weakrefset.py", line 109, in remove
    self.data.remove(ref(item))
KeyError: (<weakref at 0x000002285D440EF8; to 'Watcher' at 0x000002285D456CC0>,)
```

Which seems to indicate the object was already removed from the list. I'm guessing this because the application is already shutting down and this is a `WeakSet`, so whatever, a failure to remove an item that is not in the list, that's fine.