### PR TITLE
Scheduler unit tests

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 from .api import *

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -16,6 +16,7 @@ class Scheduler:
         self.index = 0
         self.waiting = False
         self.request_flush = self.request_flush_raise
+        self.detect_cycles = True
 
     def request_flush_raise(self):
         """
@@ -69,7 +70,7 @@ class Scheduler:
             self.has.discard(watcher.id)
             watcher.run()
 
-            if watcher.id in self.has:
+            if self.detect_cycles:  # and watcher.id in self.has:
                 self.circular[watcher.id] = self.circular.get(watcher.id, 0) + 1
                 if self.circular[watcher.id] > 100:
                     raise RecursionError(

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -3,6 +3,7 @@ The scheduler queues up and deduplicates re-evaluation of lazy Watchers
 and should be integrated in the event loop of your choosing.
 """
 from bisect import bisect
+from collections import defaultdict
 import importlib
 
 
@@ -12,7 +13,7 @@ class Scheduler:
         self._queue_indices = []
         self.flushing = False
         self.has = set()
-        self.circular = {}
+        self.circular = defaultdict(int)
         self.index = 0
         self.waiting = False
         self.request_flush = self.request_flush_raise
@@ -71,7 +72,7 @@ class Scheduler:
             watcher.run()
 
             if self.detect_cycles:  # and watcher.id in self.has:
-                self.circular[watcher.id] = self.circular.get(watcher.id, 0) + 1
+                self.circular[watcher.id] += 1
                 if self.circular[watcher.id] > 100:
                     raise RecursionError(
                         "Infinite update loop detected in watched"

--- a/poetry.lock
+++ b/poetry.lock
@@ -433,6 +433,17 @@ toml = "*"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-timeout"
+version = "1.4.2"
+description = "py.test plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -628,7 +639,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<3.10"
-content-hash = "50794712bb36b65563b8b5d7c7fd5469fedb0f4a7982b72bedde6c59a436e546"
+content-hash = "a4d90f381f24d8ac8994ed67858fda8e546f9715bc3ff11c6b201a931d912c2b"
 
 [metadata.files]
 appdirs = [
@@ -774,8 +785,6 @@ cryptography = [
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
     {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d"},
-    {file = "cryptography-3.4.8-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89"},
     {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
     {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
     {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
@@ -892,6 +901,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
     {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
+    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "observ"
-version = "0.4.1"
+version = "0.4.2"
 description = "Reactive state management for Python"
 authors = ["Korijn van Golen <korijn@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8-import-order = "*"
 flake8-print = "*"
 pytest = "*"
 pytest-cov = "*"
+pytest-timeout = "*"
 PySide6 = "*"
 twine = "*"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ import-order-style = google
 per-file-ignores =
     observ/__init__.py:F401,F403
 exclude = .venv
+
+[tool:pytest]
+timeout = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,12 @@ def noop():
 
 @pytest.fixture
 def noop_request_flush():
+    old_callback = scheduler.request_flush
     scheduler.register_request_flush(noop)
     try:
         yield
     finally:
-        scheduler.register_request_flush(scheduler.request_flush_raise)
+        scheduler.register_request_flush(old_callback)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from observ import scheduler
+
+
+def noop():
+    pass
+
+
+@pytest.fixture
+def noop_request_flush():
+    scheduler.register_request_flush(noop)
+    try:
+        yield
+    finally:
+        scheduler.register_request_flush(scheduler.request_flush_raise)
+
+
+@pytest.fixture(autouse=True)
+def clear():
+    try:
+        yield
+    finally:
+        scheduler.clear()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,9 @@ from observ import observe, scheduler, watch
 
 
 def test_no_flush_handler():
+    """
+    Test if we get a ValueError when no flush request handler is registered
+    """
     state = observe({"foo": 5, "bar": 6})
     calls = 0
 
@@ -18,6 +21,9 @@ def test_no_flush_handler():
 
 
 def test_flush(noop_request_flush):
+    """
+    Test if flush works
+    """
     state = observe({"foo": 5, "bar": 6})
     calls = 0
 
@@ -41,6 +47,10 @@ def test_flush(noop_request_flush):
 
 
 def test_cycle_expression(noop_request_flush):
+    """
+    Test if we can detect an infinite update cycle caused by
+    the watch expression
+    """
     state = observe({"foo": 5, "bar": 6})
     calls = 0
 
@@ -65,6 +75,10 @@ def test_cycle_expression(noop_request_flush):
 
 
 def test_cycle_callback(noop_request_flush):
+    """
+    Test if we can detect an infinite update cycle caused
+    by a callback
+    """
     state = observe({"foo": 5, "bar": 6})
     calls = 0
 
@@ -89,6 +103,10 @@ def test_cycle_callback(noop_request_flush):
 
 
 def test_queue_growth(noop_request_flush):
+    """
+    Test if a flush also handles watchers that are triggered
+    during the flush
+    """
     state = observe({"foo": 5, "bar": 6})
     calls_1 = 0
     calls_2 = 0
@@ -120,7 +138,11 @@ def test_queue_growth(noop_request_flush):
     assert calls_2 == 1
 
 
-def test_queue_growth_branching(noop_request_flush):
+def test_queue_cycle_indirect(noop_request_flush):
+    """
+    Test if we can detect an infinite update cycle between
+    _multiple_ watchers' callbacks
+    """
     state = observe({"foo": 5, "bar": 6})
     calls_1 = 0
     calls_2 = 0
@@ -151,9 +173,5 @@ def test_queue_growth_branching(noop_request_flush):
     assert calls_1 == 0
     assert calls_2 == 0
 
-    scheduler.flush()
-
-    assert len(scheduler._queue) == 0
-    assert len(scheduler._queue_indices) == 0
-    assert calls_1 == 1
-    assert calls_2 == 1
+    with pytest.raises(RecursionError):
+        scheduler.flush()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -147,12 +147,6 @@ def test_queue_cycle_indirect(noop_request_flush):
     calls_1 = 0
     calls_2 = 0
 
-    def exp_1():
-        if state["foo"] == 5:
-            return state["foo"]
-        else:
-            return state["bar"]
-
     def cb_1(old, new):
         nonlocal calls_1
         calls_1 += 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,120 @@
+import pytest
+
+from observ import observe, scheduler, watch
+
+
+def test_no_flush_handler():
+    state = observe({"foo": 5, "bar": 6})
+    calls = 0
+
+    def cb(old, new):
+        nonlocal calls
+        calls += 1
+
+    watcher = watch(lambda: state["foo"], cb)  # noqa: F841
+
+    with pytest.raises(ValueError, match="No flush request handler registered"):
+        state["foo"] += 1
+
+
+def test_flush(noop_request_flush):
+    state = observe({"foo": 5, "bar": 6})
+    calls = 0
+
+    def cb(old, new):
+        nonlocal calls
+        calls += 1
+
+    watcher = watch(lambda: state["foo"], cb)  # noqa: F841
+
+    state["foo"] += 1
+
+    assert len(scheduler._queue) == 1
+    assert len(scheduler._queue_indices) == 1
+    assert calls == 0
+
+    scheduler.flush()
+
+    assert len(scheduler._queue) == 0
+    assert len(scheduler._queue_indices) == 0
+    assert calls == 1
+
+
+def test_cycle_expression(noop_request_flush):
+    state = observe({"foo": 5, "bar": 6})
+    calls = 0
+
+    def exp():
+        state["foo"] += 1
+        return state["foo"]
+
+    def cb(old, new):
+        nonlocal calls
+        calls += 1
+
+    watcher = watch(exp, cb)  # noqa: F841
+
+    state["foo"] += 1
+
+    assert len(scheduler._queue) == 1
+    assert len(scheduler._queue_indices) == 1
+    assert calls == 0
+
+    with pytest.raises(RecursionError):
+        scheduler.flush()
+
+
+def test_cycle_callback(noop_request_flush):
+    state = observe({"foo": 5, "bar": 6})
+    calls = 0
+
+    def exp():
+        return state["foo"]
+
+    def cb(old, new):
+        nonlocal calls
+        calls += 1
+        state["foo"] += 1
+
+    watcher = watch(exp, cb)  # noqa: F841
+
+    state["foo"] += 1
+
+    assert len(scheduler._queue) == 1
+    assert len(scheduler._queue_indices) == 1
+    assert calls == 0
+
+    with pytest.raises(RecursionError):
+        scheduler.flush()
+
+
+def test_queue_growth(noop_request_flush):
+    state = observe({"foo": 5, "bar": 6})
+    calls_1 = 0
+    calls_2 = 0
+
+    def cb_1(old, new):
+        nonlocal calls_1
+        calls_1 += 1
+        state["bar"] += 1
+
+    def cb_2(old, new):
+        nonlocal calls_2
+        calls_2 += 1
+
+    watcher_1 = watch(lambda: state["foo"], cb_1)  # noqa: F841
+    watcher_2 = watch(lambda: state["bar"], cb_2)  # noqa: F841
+
+    state["foo"] += 1
+
+    assert len(scheduler._queue) == 1
+    assert len(scheduler._queue_indices) == 1
+    assert calls_1 == 0
+    assert calls_2 == 0
+
+    scheduler.flush()
+
+    assert len(scheduler._queue) == 0
+    assert len(scheduler._queue_indices) == 0
+    assert calls_1 == 1
+    assert calls_2 == 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -118,3 +118,42 @@ def test_queue_growth(noop_request_flush):
     assert len(scheduler._queue_indices) == 0
     assert calls_1 == 1
     assert calls_2 == 1
+
+
+def test_queue_growth_branching(noop_request_flush):
+    state = observe({"foo": 5, "bar": 6})
+    calls_1 = 0
+    calls_2 = 0
+
+    def exp_1():
+        if state["foo"] == 5:
+            return state["foo"]
+        else:
+            return state["bar"]
+
+    def cb_1(old, new):
+        nonlocal calls_1
+        calls_1 += 1
+        state["bar"] += 1
+
+    def cb_2(old, new):
+        nonlocal calls_2
+        state["foo"] += 1
+        calls_2 += 1
+
+    watcher_1 = watch(lambda: state["foo"], cb_1)  # noqa: F841
+    watcher_2 = watch(lambda: state["bar"], cb_2)  # noqa: F841
+
+    state["bar"] += 1
+
+    assert len(scheduler._queue) == 1
+    assert len(scheduler._queue_indices) == 1
+    assert calls_1 == 0
+    assert calls_2 == 0
+
+    scheduler.flush()
+
+    assert len(scheduler._queue) == 0
+    assert len(scheduler._queue_indices) == 0
+    assert calls_1 == 1
+    assert calls_2 == 1


### PR DESCRIPTION
Had to refactor the scheduler slightly to make it easier to test:

- Make it possible to configure noop request flush handler, so you can call flush manually in tests
- Make it possible to clear the scheduler manually with `scheduler.clear()` so you can reset state after tests (necessary since the scheduler is global)

Added tests for the following cases:

- Assert exception is raised when no request flush handler is registered
- Assert exception is raised when cyclical dependency in watched expression
- Assert exception is raised when cyclical dependency via watcher callback
- Assert exception is raised when cyclical dependency exists indirectly between two watchers
- Assert flush works in basic setting
- Assert flush works when a callback triggers another watcher (queue growth)

Also adds:

- `scheduler.detect_cycles` just a toggle for cycle detection, so you can disable it in prod