### PR TITLE
Support 0-2 arguments for callbacks

### DIFF
--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -53,11 +53,11 @@ class Display(QWidget):
             lambda: state["progress"], self.update_progress
         )
 
-    def update_progress(self, old_value, new_value):
+    def update_progress(self, new, old):
         # Trigger another watcher during scheduler flush
-        if new_value == 50:
+        if new == 50:
             self.state["clicked"] += 0.5
-        self.progress.setValue(new_value)
+        self.progress.setValue(new)
 
 
 class LongJob(QObject):

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -27,6 +27,7 @@ class Display(QWidget):
         super().__init__(*args, **kwargs)
 
         self.state = state
+        self.watchers = {}
 
         self.label = QLabel()
         self.progress = QProgressBar()
@@ -44,16 +45,12 @@ class Display(QWidget):
                 return "Please click the button below"
             return f"Clicked {state['clicked']} times!"
 
-        def progress_visible():
-            return state["progress"] > 0
-
-        self.watcher = watch(label_text, self.update_label, immediate=True)
-        self.progress_watch = watch(
-            lambda: state["progress"],
-            self.update_progress,
+        self.watchers["label"] = watch(label_text, self.label.setText, immediate=True)
+        self.watchers["progress_visible"] = watch(
+            lambda: state["progress"] > 0, self.progress.setVisible, immediate=True
         )
-        self.progress_visible = watch(
-            progress_visible, self.update_visibility, immediate=True
+        self.watchers["progress"] = watch(
+            lambda: state["progress"], self.update_progress
         )
 
     def update_progress(self, old_value, new_value):
@@ -61,12 +58,6 @@ class Display(QWidget):
         if new_value == 50:
             self.state["clicked"] += 0.5
         self.progress.setValue(new_value)
-
-    def update_label(self, old_value, new_value):
-        self.label.setText(new_value)
-
-    def update_visibility(self, old_value, new_value):
-        self.progress.setVisible(new_value)
 
 
 class LongJob(QObject):
@@ -122,8 +113,8 @@ class Controls(QWidget):
 
         self.button.setEnabled(False)
         self.thread.finished.connect(lambda: self.button.setEnabled(True))
-        self.worker.result.connect(lambda x: bump(x))
-        self.worker.progress.connect(lambda x: progress(x))
+        self.worker.result.connect(bump)
+        self.worker.progress.connect(progress)
 
     def on_reset_clicked(self):
         self.state["clicked"] = 0
@@ -135,6 +126,7 @@ if __name__ == "__main__":
 
     app = QApplication([])
 
+    # Register with Qt's event loop
     scheduler.register_qt()
 
     # Create layout and pass state to widgets

--- a/observ/api.py
+++ b/observ/api.py
@@ -33,5 +33,5 @@ def watch(fn, callback, sync=False, deep=False, immediate=False):
         watcher.dirty = True
         watcher.evaluate()
         if watcher.callback:
-            watcher.callback(None, watcher.value)
+            watcher.run_callback(None, watcher.value)
     return watcher

--- a/observ/api.py
+++ b/observ/api.py
@@ -33,5 +33,5 @@ def watch(fn, callback, sync=False, deep=False, immediate=False):
         watcher.dirty = True
         watcher.evaluate()
         if watcher.callback:
-            watcher.run_callback(None, watcher.value)
+            watcher.run_callback(watcher.value, None)
     return watcher

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -53,6 +53,7 @@ class Watcher:
         self.lazy = lazy
         self.dirty = self.lazy
         self.value = None if self.lazy else self.get()
+        self._number_of_callback_args = None
 
     def update(self) -> None:
         if self.lazy:
@@ -73,7 +74,37 @@ class Watcher:
             old_value = self.value
             self.value = value
             if self.callback:
-                self.callback(old_value, self.value)
+                self.run_callback(old_value, self.value)
+
+    def run_callback(self, old, new):
+        """
+        Runs the callback. When the number of arguments is still unknown
+        for the callback, it will fall into the try/except contstruct
+        to figure out the right number of arguments.
+        After running the callback one time, the number of arguments
+        is known and the callback can be called with the correct
+        amount of arguments.
+        """
+        if self._number_of_callback_args == 1:
+            self.callback(new)
+            return
+        if self._number_of_callback_args == 2:
+            self.callback(old, new)
+            return
+        if self._number_of_callback_args == 0:
+            self.callback()
+            return
+
+        try:
+            self.callback(new)
+            self._number_of_callback_args = 1
+        except TypeError:
+            try:
+                self.callback(old, new)
+                self._number_of_callback_args = 2
+            except TypeError:
+                self.callback()
+                self._number_of_callback_args = 0
 
     def get(self) -> Any:
         Dep.stack.append(self)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,3 +1,5 @@
+import pytest
+
 from observ import computed, observe, watch
 
 
@@ -108,3 +110,38 @@ def test_usage_deep_vs_non_deep():
     a["foo"].append(1)
     assert non_deep_called == 0
     assert deep_called == 1
+
+
+def test_callback_signatures():
+    a = observe({"foo": 0})
+    called = 0
+
+    def empty_callback():
+        nonlocal called
+        called += 1
+
+    watcher = watch(lambda: a["foo"], empty_callback, sync=True, immediate=True)
+    assert called == 1
+
+    def simple_callback(value):
+        nonlocal called
+        called += 1
+
+    watcher = watch(lambda: a["foo"], simple_callback, sync=True, immediate=True)
+    assert called == 2
+
+    def full_callback(old, new):
+        nonlocal called
+        called += 1
+
+    watcher = watch(lambda: a["foo"], full_callback, sync=True, immediate=True)
+    assert called == 3
+
+    def too_complex_callback(old, new, other):
+        nonlocal called
+        called += 1
+
+    with pytest.raises(TypeError):
+        watcher = watch(  # noqa: F841
+            lambda: a["foo"], too_complex_callback, sync=True, immediate=True
+        )


### PR DESCRIPTION
Here's my attempt at supporting callbacks with 0-2 arguments.

Instead of having to add (and name) an extra argument in the `watch` function, I decided to try a different route (which also supports callbacks without arguments).
We also played with the idea of specifying how many arguments the callback has, but that has the downside of being verbose in some cases.

What if the watcher just tries out which callback works and then take note of how many arguments it used? Seems to work and doesn't give any overhead for repeated calls to `run_callback` (I did ran some benchmarks to verify this).

Before running some benchmarks, I had some 'smart' code for passing the right amount of arguments to the callback (`self.callback(*[old, new][2 - nr :])`), but the benchmarks pointed out that a simple `if ... == ...` test was significantly faster. 

So, what do you think?