### PR TITLE
Proxies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: local
+  hooks:
+  - id: flake8
+    name: Linting
+    entry: poetry run flake8
+    language: system
+    types: [python]
+    require_serial: true
+- repo: local
+  hooks:
+  - id: pytest
+    name: Tests
+    entry: poetry run pytest
+    language: system
+    types: [python]
+    pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Install observ with pip/pipenv/poetry:
 `pip install observ`
 
 Check out [`examples/observe_qt.py`](https://github.com/Korijn/observ/blob/master/examples/observe_qt.py) for a simple example using observ.
+
+## Caveats
+
+Observ keeps references to the object passed to the `reactive` in order to keep track of dependencies and proxies for that object. When the object that is passed into `reactive` is not managed by other code, then observ should cleanup its references automatically when the proxy is destroyed. However, if there is another reference to the original object, then observ will only release its own reference when the garbage collector is run and all other references to the object are gone.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Observ provides the following two benefits for stateful applications:
 
 * `state = reactive(state)`
 
-Observe nested structures of dicts, lists, tuples and sets. Returns an observable clone of the state input object.
+Observe nested structures of dicts, lists, tuples and sets. Returns an observable proxy that wraps the state input object.
 
 * `watcher = watch(func, callback, deep=False, immediate=False)`
 
@@ -38,7 +38,3 @@ Install observ with pip/pipenv/poetry:
 `pip install observ`
 
 Check out [`examples/observe_qt.py`](https://github.com/Korijn/observ/blob/master/examples/observe_qt.py) for a simple example using observ.
-
-## Caveats
-
-The reactive counterparts (DictProxy, ListProxy and SetProxy) of dict, list and set *are* hashable, unlike the originals. That makes it possible to use them as keys in dicts and to include them in sets. This is probably not a good idea if you are ever to call `to_raw` on your data structure, because that will surely break.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Observ provides the following two benefits for stateful applications:
 
 ## API
 
-`from observ import observe, computed, watch`
+`from observ import reactive, computed, watch`
 
-* `state = observe(state)`
+* `state = reactive(state)`
 
 Observe nested structures of dicts, lists, tuples and sets. Returns an observable clone of the state input object.
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Install observ with pip/pipenv/poetry:
 `pip install observ`
 
 Check out [`examples/observe_qt.py`](https://github.com/Korijn/observ/blob/master/examples/observe_qt.py) for a simple example using observ.
+
+## Caveats
+
+The reactive counterparts (DictProxy, ListProxy and SetProxy) of dict, list and set *are* hashable, unlike the originals. That makes it possible to use them as keys in dicts and to include them in sets. This is probably not a good idea if you are ever to call `to_raw` on your data structure, because that will surely break.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Observ 👁
 
-Observ is a Python port of [Vue.js](https://vuejs.org/)' [computed properties and watchers](https://vuejs.org/v2/guide/computed.html). It is completely event loop/framework agnostic and has no dependencies so it can be used in any project targeting Python >= 3.6.
+Observ is a Python port of [Vue.js](https://vuejs.org/)' [computed properties and watchers](https://v3.vuejs.org/api/basic-reactivity.html). It is completely event loop/framework agnostic and has no dependencies so it can be used in any project targeting Python >= 3.6.
 
 Observ provides the following two benefits for stateful applications:
 

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from observ import observe, scheduler, watch
+from observ import reactive, scheduler, watch
 
 
 class Display(QWidget):
@@ -122,7 +122,7 @@ class Controls(QWidget):
 
 if __name__ == "__main__":
     # Define some state
-    state = observe({"clicked": 0, "progress": 0})
+    state = reactive({"clicked": 0, "progress": 0})
 
     app = QApplication([])
 

--- a/observ/api.py
+++ b/observ/api.py
@@ -4,12 +4,12 @@ Defines the public API for observ users
 from functools import wraps
 
 from .dep import Dep
-from .observables import observe
+from .observables import reactive
 from .scheduler import scheduler
 from .watcher import Watcher
 
 
-__all__ = ("observe", "computed", "watch", "scheduler")
+__all__ = ("reactive", "computed", "watch", "scheduler")
 
 
 def computed(fn):

--- a/observ/api.py
+++ b/observ/api.py
@@ -13,7 +13,7 @@ __all__ = ("reactive", "computed", "watch", "scheduler", "to_raw")
 
 
 def computed(fn):
-    watcher = Watcher(fn)
+    watcher = Watcher(fn, readonly=True)
 
     @wraps(fn)
     def getter():

--- a/observ/api.py
+++ b/observ/api.py
@@ -13,7 +13,7 @@ __all__ = ("reactive", "computed", "watch", "scheduler", "to_raw")
 
 
 def computed(fn):
-    watcher = Watcher(fn, readonly=True)
+    watcher = Watcher(fn)
 
     @wraps(fn)
     def getter():

--- a/observ/api.py
+++ b/observ/api.py
@@ -1,15 +1,24 @@
 """
 Defines the public API for observ users
 """
-from functools import wraps
+from functools import partial, wraps
 
 from .dep import Dep
-from .observables import reactive, to_raw
+from .observables import proxy, to_raw
 from .scheduler import scheduler
 from .watcher import Watcher
 
 
-__all__ = ("reactive", "computed", "watch", "scheduler", "to_raw")
+__all__ = (
+    "reactive",
+    "readonly",
+    "shallow_reactive",
+    "shallow_readonly",
+    "computed",
+    "watch",
+    "scheduler",
+    "to_raw",
+)
 
 
 def computed(fn):
@@ -35,3 +44,9 @@ def watch(fn, callback, sync=False, deep=False, immediate=False):
         if watcher.callback:
             watcher.run_callback(watcher.value, None)
     return watcher
+
+
+reactive = partial(proxy)
+readonly = partial(proxy, readonly=True)
+shallow_reactive = partial(proxy, shallow=True)
+shallow_readonly = partial(proxy, shallow=True, readonly=True)

--- a/observ/api.py
+++ b/observ/api.py
@@ -4,12 +4,12 @@ Defines the public API for observ users
 from functools import wraps
 
 from .dep import Dep
-from .observables import reactive
+from .observables import reactive, to_raw
 from .scheduler import scheduler
 from .watcher import Watcher
 
 
-__all__ = ("reactive", "computed", "watch", "scheduler")
+__all__ = ("reactive", "computed", "watch", "scheduler", "to_raw")
 
 
 def computed(fn):

--- a/observ/api.py
+++ b/observ/api.py
@@ -46,7 +46,7 @@ def watch(fn, callback, sync=False, deep=False, immediate=False):
     return watcher
 
 
-reactive = partial(proxy)
+reactive = proxy
 readonly = partial(proxy, readonly=True)
 shallow_reactive = partial(proxy, shallow=True)
 shallow_readonly = partial(proxy, shallow=True, readonly=True)

--- a/observ/dep.py
+++ b/observ/dep.py
@@ -10,7 +10,7 @@ class Dep:
     stack: List["Watcher"] = []  # noqa: F821
 
     def __init__(self) -> None:
-        self._subs = WeakSet()
+        self._subs: WeakSet["Watcher"] = WeakSet()  # noqa: F821
 
     def add_sub(self, sub: "Watcher") -> None:  # noqa: F821
         self._subs.add(sub)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -239,6 +239,8 @@ def write_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
+        if Dep.stack and Dep.stack[-1].readonly:
+            raise ReadonlyError()
         args = tuple(proxy(a) for a in args)
         kwargs = {k: proxy(v) for k, v in kwargs.items()}
         retval = fn(self.target, *args, **kwargs)
@@ -255,6 +257,8 @@ def write_key_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
+        if Dep.stack and Dep.stack[-1].readonly:
+            raise ReadonlyError()
         key = args[0]
         is_new = key not in proxy_db.attrs(self)["keydep"]
         old_value = getitem_fn(self.target, key) if not is_new else None
@@ -277,6 +281,8 @@ def delete_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
+        if Dep.stack and Dep.stack[-1].readonly:
+            raise ReadonlyError()
         retval = fn(self.target, *args, **kwargs)
         proxy_db.attrs(self)["dep"].notify()
         for key in self._orphaned_keydeps():
@@ -292,6 +298,8 @@ def delete_key_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
+        if Dep.stack and Dep.stack[-1].readonly:
+            raise ReadonlyError()
         retval = fn(self.target, *args, **kwargs)
         key = args[0]
         proxy_db.attrs(self)["dep"].notify()

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -13,8 +13,9 @@ def observe(obj, deep=True, readonly=False):
     if not isinstance(obj, (dict, list, tuple, set)):
         return obj  # common case first
     elif isinstance(obj, dict):
+        cls = ReadonlyDictProxy if readonly else DictProxy
         if not isinstance(obj, DictProxyBase):
-            reactive = ReadonlyDictProxy(obj) if readonly else DictProxy(obj)
+            reactive = cls(obj)
         else:
             reactive = obj
         if deep:
@@ -22,8 +23,9 @@ def observe(obj, deep=True, readonly=False):
                 reactive[k] = observe(v, deep=deep, readonly=readonly)
         return reactive
     elif isinstance(obj, list):
+        cls = ReadonlyListProxy if readonly else ListProxy
         if not isinstance(obj, ListProxyBase):
-            reactive = ReadonlyListProxy(obj) if readonly else ListProxy(obj)
+            reactive = cls(obj)
         else:
             reactive = obj
         if deep:

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -269,8 +269,8 @@ def write_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        args = tuple(observe(a) for a in args)
-        kwargs = {k: observe(v) for k, v in kwargs.items()}
+        args = tuple(reactive(a) for a in args)
+        kwargs = {k: reactive(v) for k, v in kwargs.items()}
         retval = fn(self.target, *args, **kwargs)
         # TODO: prevent firing if value hasn't actually changed?
         proxy_db.attrs(self)["dep"].notify()
@@ -288,8 +288,8 @@ def write_key_trap(method, obj_cls):
         key = args[0]
         is_new = key not in proxy_db.attrs(self)["keydep"]
         old_value = getitem_fn(self.target, key) if not is_new else None
-        args = [key] + [observe(a) for a in args[1:]]
-        kwargs = {k: observe(v) for k, v in kwargs.items()}
+        args = [key] + [reactive(a) for a in args[1:]]
+        kwargs = {k: reactive(v) for k, v in kwargs.items()}
         retval = fn(self.target, *args, **kwargs)
         new_value = getitem_fn(self.target, key)
         if is_new:
@@ -576,7 +576,3 @@ class ReadonlySetProxy(SetProxyBase):
 
 make_observable(SetProxy, set, set_traps, trap_map)
 make_observable(ReadonlySetProxy, set, set_traps, trap_map_readonly)
-
-
-def observe(target):
-    return reactive(target=target)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -148,21 +148,23 @@ def proxy(target, readonly=False, shallow=False):
 
     Please be aware: this only works on plain data types!
     """
-    # The object may be a proxy already
-    # (exception is when we want a readonly proxy on a writable proxy)
+    # The object may be a proxy already, so check if it matches the
+    # given configuration (readonly and shallow)
     if isinstance(target, Proxy):
-        if not (readonly and not target.readonly):
+        if readonly == target.readonly and shallow == target.shallow:
             return target
         else:
-            # Unpack the target from the proxy to create
-            # a new proxy further down this function
+            # If the configuration does not match,
+            # unwrap the target from the proxy so that the right
+            # kind of proxy can be returned in the next part of
+            # this function
             target = target.target
 
-    # There may already be a proxy for this object
-    if not isinstance(target, Proxy):
-        existing_proxy = proxy_db.get_proxy(target, readonly=readonly, shallow=shallow)
-        if existing_proxy is not None:
-            return existing_proxy
+    # Note that at this point, target is always a non-proxy object
+    # Check the proxy_db to see if there's already a proxy for the target object
+    existing_proxy = proxy_db.get_proxy(target, readonly=readonly, shallow=shallow)
+    if existing_proxy is not None:
+        return existing_proxy
 
     # We can only wrap the following datatypes
     if not isinstance(target, (dict, list, tuple, set)):

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -244,8 +244,8 @@ def write_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        args = tuple(reactive(a) for a in args)
-        kwargs = {k: reactive(v) for k, v in kwargs.items()}
+        args = tuple(proxy(a) for a in args)
+        kwargs = {k: proxy(v) for k, v in kwargs.items()}
         retval = fn(self.target, *args, **kwargs)
         # TODO: prevent firing if value hasn't actually changed?
         proxy_db.attrs(self)["dep"].notify()
@@ -263,8 +263,8 @@ def write_key_trap(method, obj_cls):
         key = args[0]
         is_new = key not in proxy_db.attrs(self)["keydep"]
         old_value = getitem_fn(self.target, key) if not is_new else None
-        args = [key] + [reactive(a) for a in args[1:]]
-        kwargs = {k: reactive(v) for k, v in kwargs.items()}
+        args = [key] + [proxy(a) for a in args[1:]]
+        kwargs = {k: proxy(v) for k, v in kwargs.items()}
         retval = fn(self.target, *args, **kwargs)
         new_value = getitem_fn(self.target, key)
         if is_new:

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -355,6 +355,8 @@ if sys.version_info >= (3, 9, 0):
     dict_traps["WRITERS"].add("__ior__")
 
 
+# TODO: should this subclass dict, so that users can work with
+# isinstance(x, dict) on their state objects?
 class DictProxyBase(Proxy):
     def __init__(self, target, readonly=False, shallow=False):
         super().__init__(target, readonly=readonly, shallow=shallow)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -176,12 +176,6 @@ def proxy(target, readonly=False, shallow=False):
     return proxy_type(target, readonly=readonly, shallow=shallow)
 
 
-reactive = partial(proxy)
-readonly = partial(proxy, readonly=True)
-shallow_reactive = partial(proxy, shallow=True)
-shallow_readonly = partial(proxy, shallow=True, readonly=True)
-
-
 class StateModifiedError(Exception):
     """
     Raised when a proxy is modified in a watched (or computed) expression.

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -8,138 +8,171 @@ import sys
 from .dep import Dep
 
 
-def observe(obj, deep=True):
+def observe(obj, deep=True, readonly=False):
     """Please be aware: this only works on plain data types!"""
     if not isinstance(obj, (dict, list, tuple, set)):
         return obj  # common case first
     elif isinstance(obj, dict):
-        if not isinstance(obj, ObservableDict):
-            reactive = ObservableDict(obj)
+        if not isinstance(obj, DictProxyBase):
+            reactive = ReadonlyDictProxy(obj) if readonly else DictProxy(obj)
         else:
             reactive = obj
         if deep:
             for k, v in reactive.items():
-                reactive[k] = observe(v)
+                reactive[k] = observe(v, deep=deep, readonly=readonly)
         return reactive
     elif isinstance(obj, list):
-        if not isinstance(obj, ObservableList):
-            reactive = ObservableList(obj)
+        if not isinstance(obj, ListProxyBase):
+            reactive = ReadonlyListProxy(obj) if readonly else ListProxy(obj)
         else:
             reactive = obj
         if deep:
             for i, v in enumerate(reactive):
-                reactive[i] = observe(v)
+                reactive[i] = observe(v, deep=deep, readonly=readonly)
         return reactive
     elif isinstance(obj, tuple):
         reactive = obj  # tuples are immutable
         if deep:
-            reactive = tuple(observe(v) for v in reactive)
+            reactive = tuple(observe(v, deep=deep, readonly=readonly) for v in reactive)
         return reactive
     elif isinstance(obj, set):
+        cls = ReadonlySetProxy if readonly else SetProxy
         if deep:
-            return ObservableSet(observe(v) for v in obj)
+            return cls({observe(v, deep=deep, readonly=readonly) for v in obj})
         else:
-            if not isinstance(obj, ObservableSet):
-                reactive = ObservableSet(obj)
+            if not isinstance(obj, SetProxyBase):
+                reactive = cls(obj)
             else:
                 reactive = obj
             return reactive
 
 
-def make_observable(cls):
-    def read(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
-            if Dep.stack:
-                self.__dep__.depend()
-            return fn(self, *args, **kwargs)
+def read_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        if Dep.stack:
+            self.__dep__.depend()
+        return fn(self, *args, **kwargs)
 
-        return inner
+    return inner
 
-    def read_key(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
-            if Dep.stack:
-                key = args[0]
-                self.__keydeps__[key].depend()
-            return fn(self, *args, **kwargs)
 
-        return inner
-
-    def write(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
-            args = tuple(observe(a) for a in args)
-            kwargs = {k: observe(v) for k, v in kwargs.items()}
-            retval = fn(self, *args, **kwargs)
-            # TODO prevent firing if value hasn't actually changed?
-            self.__dep__.notify()
-            return retval
-
-        return inner
-
-    def write_key(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
+def read_key_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        if Dep.stack:
             key = args[0]
-            is_new = key not in self.__keydeps__
-            old_value = cls.__getitem__(self, key) if not is_new else None
-            args = [key] + [observe(a) for a in args[1:]]
-            kwargs = {k: observe(v) for k, v in kwargs.items()}
-            retval = fn(self, *args, **kwargs)
-            new_value = cls.__getitem__(self, key)
-            if is_new:
-                self.__keydeps__[key] = Dep()
-            if old_value != new_value:
-                self.__keydeps__[key].notify()
-                self.__dep__.notify()
-            return retval
+            self.__keydeps__[key].depend()
+        return fn(self, *args, **kwargs)
 
-        return inner
+    return inner
 
-    def delete(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
-            retval = fn(self, *args, **kwargs)
+
+def write_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        args = tuple(observe(a) for a in args)
+        kwargs = {k: observe(v) for k, v in kwargs.items()}
+        retval = fn(self, *args, **kwargs)
+        # TODO prevent firing if value hasn't actually changed?
+        self.__dep__.notify()
+        return retval
+
+    return inner
+
+
+def write_key_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    getitem_fn = getattr(obj_cls, "__getitem__")
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        key = args[0]
+        is_new = key not in self.__keydeps__
+        old_value = getitem_fn(self, key) if not is_new else None
+        args = [key] + [observe(a) for a in args[1:]]
+        kwargs = {k: observe(v) for k, v in kwargs.items()}
+        retval = fn(self, *args, **kwargs)
+        new_value = getitem_fn(self, key)
+        if is_new:
+            self.__keydeps__[key] = Dep()
+        if old_value != new_value:
+            self.__keydeps__[key].notify()
             self.__dep__.notify()
-            for key in self._orphaned_keydeps():
-                self.__keydeps__[key].notify()
-                del self.__keydeps__[key]
-            return retval
+        return retval
 
-        return inner
+    return inner
 
-    def delete_key(fn):
-        @wraps(fn)
-        def inner(self, *args, **kwargs):
-            retval = fn(self, *args, **kwargs)
-            key = args[0]
-            self.__dep__.notify()
+
+def delete_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        retval = fn(self, *args, **kwargs)
+        self.__dep__.notify()
+        for key in self._orphaned_keydeps():
             self.__keydeps__[key].notify()
             del self.__keydeps__[key]
-            return retval
+        return retval
 
-        return inner
-
-    todo = [
-        ("_READERS", read),
-        ("_KEYREADERS", read_key),
-        ("_WRITERS", write),
-        ("_KEYWRITERS", write_key),
-        ("_DELETERS", delete),
-        ("_KEYDELETERS", delete_key),
-    ]
-
-    for category, decorate in todo:
-        for name in getattr(cls, category, set()):
-            fn = getattr(cls, name)
-            setattr(cls, name, decorate(fn))
-
-    return cls
+    return inner
 
 
-class ObservableDict(dict):
-    _READERS = {
+def delete_key_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        retval = fn(self, *args, **kwargs)
+        key = args[0]
+        self.__dep__.notify()
+        self.__keydeps__[key].notify()
+        del self.__keydeps__[key]
+        return retval
+
+    return inner
+
+
+trap_map = {
+    "READERS": read_trap,
+    "KEYREADERS": read_key_trap,
+    "WRITERS": write_trap,
+    "KEYWRITERS": write_key_trap,
+    "DELETERS": delete_trap,
+    "KEYDELETERS": delete_key_trap,
+}
+
+class ReadonlyError(Exception):
+    pass
+
+
+def readonly_trap(method, proxy_cls, obj_cls):
+    fn = getattr(obj_cls, method)
+    @wraps(fn)
+    def inner(self, *args, **kwargs):
+        raise ReadonlyError()
+
+    return inner
+
+trap_map_readonly = {
+    "READERS": read_trap,
+    "KEYREADERS": read_key_trap,
+    "WRITERS": readonly_trap,
+    "KEYWRITERS": readonly_trap,
+    "DELETERS": readonly_trap,
+    "KEYDELETERS": readonly_trap,
+}
+
+def make_observable(proxy_cls, obj_cls, traps, trap_map):
+    for trap_type, methods in traps.items():
+        for method in methods:
+            trap = trap_map[trap_type](method, proxy_cls, obj_cls)
+            setattr(proxy_cls, method, trap)
+
+
+dict_traps = {
+    "READERS": {
         "values",
         "copy",
         "items",
@@ -157,49 +190,65 @@ class ObservableDict(dict):
         "__sizeof__",
         "__str__",
     }
-    _KEYREADERS = {
+    "KEYREADERS": {
         "get",
         "__contains__",
         "__getitem__",
     }
-    _WRITERS = {
+    "WRITERS": {
         "update",
     }
-    _KEYWRITERS = {
+    "KEYWRITERS": {
         "setdefault",
         "__setitem__",
     }
-    _DELETERS = {
+    "DELETERS": {
         "clear",
         "popitem",
     }
-    _KEYDELETERS = {
+    "KEYDELETERS": {
         "pop",
         "__delitem__",
-    }
-
-    @wraps(dict.__init__)
-    def __init__(self, *args, **kwargs):
-        dict.__init__(self, *args, **kwargs)
-        self.__dep__ = Dep()
-        self.__keydeps__ = {key: Dep() for key in dict.keys(self)}
-
-    def _orphaned_keydeps(self):
-        return set(self.__keydeps__.keys()) - set(dict.keys(self))
-
+    },
+}
 
 if sys.version_info >= (3, 8, 0):
-    ObservableDict._READERS.add("__reversed__")
+    dict_traps["READERS"].add("__reversed__")
 if sys.version_info >= (3, 9, 0):
-    ObservableDict._READERS.add("__or__")
-    ObservableDict._READERS.add("__ror__")
-    ObservableDict._WRITERS.add("__ior__")
-ObservableDict = make_observable(ObservableDict)
+    dict_traps["READERS"].add("__or__")
+    dict_traps["READERS"].add("__ror__")
+    dict_traps["WRITERS"].add("__ior__")
 
 
-@make_observable
-class ObservableList(list):
-    _READERS = {
+class ProxyBase:
+    def __init__(self, obj):
+        self._obj = obj
+
+
+class DictProxyBase(ProxyBase):
+    def __init__(self, obj):
+        super().__init__(obj)
+        self.__dep__ = Dep()
+        self.__keydeps__ = {key: Dep() for key in self._obj.keys()}
+
+    def _orphaned_keydeps(self):
+        return set(self.__keydeps__.keys()) - set(self._obj.keys())
+
+
+class DictProxy(DictProxyBase):
+    pass
+
+
+class ReadonlyDictProxy(DictProxyBase):
+    pass
+
+
+make_observable(DictProxy, dict, dict_traps, trap_map)
+make_observable(ReadonlyDictProxy, dict, dict_traps, trap_map_readonly)
+
+
+list_traps = {
+    "READERS": {
         "count",
         "index",
         "copy",
@@ -222,7 +271,7 @@ class ObservableList(list):
         "__reversed__",
         "__sizeof__",
     }
-    _WRITERS = {
+    "WRITERS": {
         "append",
         "clear",
         "extend",
@@ -236,16 +285,29 @@ class ObservableList(list):
         "__iadd__",
         "__imul__",
     }
+}
 
-    @wraps(list.__init__)
-    def __init__(self, *args, **kwargs):
-        list.__init__(self, *args, **kwargs)
+
+class ListProxyBase(ProxyBase):
+    def __init__(self, obj):
+        super().__init__(obj)
         self.__dep__ = Dep()
 
 
-@make_observable
-class ObservableSet(set):
-    _READERS = {
+class ListProxy(ListProxyBase):
+    pass
+
+
+class ReadonlyListProxy(ListProxyBase):
+    pass
+
+
+make_observable(ListProxy, list, list_traps, trap_map)
+make_observable(ReadonlyListProxy, list, list_traps, trap_map_readonly)
+
+
+set_traps = {
+    "READERS": {
         "copy",
         "difference",
         "intersection",
@@ -280,7 +342,7 @@ class ObservableSet(set):
         "__sub__",
         "__xor__",
     }
-    _WRITERS = {
+    "WRITERS": {
         "add",
         "clear",
         "difference_update",
@@ -291,8 +353,22 @@ class ObservableSet(set):
         "symmetric_difference_update",
         "update",
     }
+}
 
-    @wraps(set.__init__)
-    def __init__(self, *args, **kwargs):
-        set.__init__(self, *args, **kwargs)
+
+class SetProxyBase(ProxyBase):
+    def __init__(self, obj):
+        super().__init__(obj)
         self.__dep__ = Dep()
+
+
+class SetProxy(SetProxyBase):
+    pass
+
+
+class ReadonlySetProxy(SetProxyBase):
+    pass
+
+
+make_observable(SetProxy, set, set_traps, trap_map)
+make_observable(ReadonlySetProxy, set, set_traps, trap_map_readonly)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -170,8 +170,7 @@ def proxy(target, readonly=False, shallow=False):
     elif isinstance(target, set):
         proxy_type = SetProxy if not readonly else ReadonlySetProxy
     elif isinstance(target, tuple):
-        # FIXME: think of what needs to be done for tuple
-        proxy_type = Proxy
+        return tuple(proxy(x, readonly=readonly, shallow=shallow) for x in target)
     return proxy_type(target, readonly=readonly, shallow=shallow)
 
 

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -357,8 +357,8 @@ class DictProxy(DictProxyBase):
 
 
 class ReadonlyDictProxy(DictProxyBase):
-    def __init__(self, target):
-        super().__init__(target, readonly=True, shallow=False)
+    def __init__(self, target, shallow=False, **kwargs):
+        super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
 make_observable(DictProxy, dict, dict_traps, trap_map)
@@ -416,8 +416,8 @@ class ListProxy(ListProxyBase):
 
 
 class ReadonlyListProxy(ListProxyBase):
-    def __init__(self, target):
-        super().__init__(target, readonly=True, shallow=False)
+    def __init__(self, target, shallow=False, **kwargs):
+        super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
 make_observable(ListProxy, list, list_traps, trap_map)
@@ -484,8 +484,8 @@ class SetProxy(SetProxyBase):
 
 
 class ReadonlySetProxy(SetProxyBase):
-    def __init__(self, target):
-        super().__init__(target, readonly=True)
+    def __init__(self, target, shallow=False, **kwargs):
+        super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
 make_observable(SetProxy, set, set_traps, trap_map)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -352,7 +352,7 @@ trap_map_readonly = {
 }
 
 
-def make_reactive(proxy_cls, obj_cls, traps, trap_map):
+def bind_traps(proxy_cls, obj_cls, traps, trap_map):
     for trap_type, methods in traps.items():
         for method in methods:
             trap = trap_map[trap_type](method, obj_cls)
@@ -427,8 +427,8 @@ class ReadonlyDictProxy(DictProxyBase):
         super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
-make_reactive(DictProxy, dict, dict_traps, trap_map)
-make_reactive(ReadonlyDictProxy, dict, dict_traps, trap_map_readonly)
+bind_traps(DictProxy, dict, dict_traps, trap_map)
+bind_traps(ReadonlyDictProxy, dict, dict_traps, trap_map_readonly)
 
 
 list_traps = {
@@ -488,8 +488,8 @@ class ReadonlyListProxy(ListProxyBase):
         super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
-make_reactive(ListProxy, list, list_traps, trap_map)
-make_reactive(ReadonlyListProxy, list, list_traps, trap_map_readonly)
+bind_traps(ListProxy, list, list_traps, trap_map)
+bind_traps(ReadonlyListProxy, list, list_traps, trap_map_readonly)
 
 
 set_traps = {
@@ -558,8 +558,8 @@ class ReadonlySetProxy(SetProxyBase):
         super().__init__(target, shallow=shallow, **{**kwargs, "readonly": True})
 
 
-make_reactive(SetProxy, set, set_traps, trap_map)
-make_reactive(ReadonlySetProxy, set, set_traps, trap_map_readonly)
+bind_traps(SetProxy, set, set_traps, trap_map)
+bind_traps(ReadonlySetProxy, set, set_traps, trap_map_readonly)
 
 
 def to_raw(target):

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -58,7 +58,14 @@ class ProxyDb:
         """
         obj_id = id(proxy.target)
         self.db[obj_id]["ref"] -= 1
-        self.db[obj_id]["proxies"][proxy.readonly][proxy.shallow].remove(proxy)
+        try:
+            self.db[obj_id]["proxies"][proxy.readonly][proxy.shallow].remove(proxy)
+        except KeyError:
+            # During assertion errors in the test suite, the proxy might
+            # already be removed from the WeakSet, so this try/except is
+            # to make sure you won't see a KeyError when an assertion error
+            # occurs.
+            pass
         if self.db[obj_id]["ref"] == 0:
             del self.db[obj_id]
         elif self.db[obj_id]["ref"] < 0:

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -90,6 +90,13 @@ class ProxyDb:
         Removes a reference from the
         """
         obj_id = id(proxy.target)
+        if obj_id not in self.db:
+            # When there are failing tests, it might happen that proxies
+            # are garbage collected at a point where the proxy_db is already
+            # cleared. That's why we need this check here.
+            # See fixture [clear_proxy_db](/tests/conftest.py:clear_proxy_db)
+            # for more info.
+            return
         self.db[obj_id]["refs"] -= 1
 
         if self.db[obj_id]["refs"] <= 0:

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -46,23 +46,6 @@ class ProxyDb:
         for keys in keys_to_delete:
             del self.db[keys]
 
-    def register_target(self, target):
-        """
-        Creates an entry for the given target (object) and adds a strong
-        reference. The items
-        """
-        attrs = {
-            "dep": Dep(),
-        }
-        if isinstance(target, dict):
-            attrs["keydep"] = {key: Dep() for key in target.keys()}
-        self.db[id(target)] = {
-            "target": target,
-            "attrs": attrs,  # dep, keydep
-            # keyed on tuple(readonly, shallow)
-            "proxies": WeakValueDictionary(),
-        }
-
     def reference(self, proxy):
         """
         Adds a reference to the collection for the wrapped object's id
@@ -70,7 +53,17 @@ class ProxyDb:
         obj_id = id(proxy.target)
 
         if obj_id not in self.db:
-            self.register_target(proxy.target)
+            attrs = {
+                "dep": Dep(),
+            }
+            if isinstance(proxy.target, dict):
+                attrs["keydep"] = {key: Dep() for key in proxy.target.keys()}
+            self.db[obj_id] = {
+                "target": proxy.target,
+                "attrs": attrs,  # dep, keydep
+                # keyed on tuple(readonly, shallow)
+                "proxies": WeakValueDictionary(),
+            }
 
         # Use setdefault to put the proxy in the proxies dict. If there
         # was an existing value, it will return that instead. There shouldn't

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -165,9 +165,7 @@ def read_trap(method, obj_cls):
 
     @wraps(fn)
     def trap(self, *args, **kwargs):
-        # If we are tracking changes
         if Dep.stack:
-            # Mark as a dependency
             proxy_db.attrs(self)["dep"].depend()
         value = fn(self.target, *args, **kwargs)
         if self.shallow:
@@ -182,12 +180,13 @@ def read_key_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        # If we are tracking changes
         if Dep.stack:
-            # Mark as a dependency
             key = args[0]
             proxy_db.attrs(self)["keydep"][key].depend()
-        return fn(self.target, *args, **kwargs)
+        value = fn(self.target, *args, **kwargs)
+        if self.shallow:
+            return value
+        return proxy(value, readonly=self.readonly)
 
     return inner
 

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -239,7 +239,7 @@ def write_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        if Dep.stack and Dep.stack[-1].readonly:
+        if Dep.stack:
             raise ReadonlyError()
         args = tuple(proxy(a) for a in args)
         kwargs = {k: proxy(v) for k, v in kwargs.items()}
@@ -257,7 +257,7 @@ def write_key_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        if Dep.stack and Dep.stack[-1].readonly:
+        if Dep.stack:
             raise ReadonlyError()
         key = args[0]
         is_new = key not in proxy_db.attrs(self)["keydep"]
@@ -281,7 +281,7 @@ def delete_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        if Dep.stack and Dep.stack[-1].readonly:
+        if Dep.stack:
             raise ReadonlyError()
         retval = fn(self.target, *args, **kwargs)
         proxy_db.attrs(self)["dep"].notify()
@@ -298,7 +298,7 @@ def delete_key_trap(method, obj_cls):
 
     @wraps(fn)
     def inner(self, *args, **kwargs):
-        if Dep.stack and Dep.stack[-1].readonly:
+        if Dep.stack:
             raise ReadonlyError()
         retval = fn(self.target, *args, **kwargs)
         key = args[0]

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -215,12 +215,9 @@ def iterate_trap(method, obj_cls):
         if self.shallow:
             return iterator
         if method == "items":
-
-            def proxy_dict_items(iterator, readonly=False):
-                for key, value in iterator:
-                    yield key, proxy(value, readonly=readonly)
-
-            return proxy_dict_items(iterator, readonly=self.readonly)
+            return (
+                (key, proxy(value, readonly=self.readonly)) for key, value in iterator
+            )
         else:
             proxied = partial(proxy, readonly=self.readonly)
             return map(proxied, iterator)

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -218,10 +218,7 @@ def iterate_trap(method, obj_cls):
 
             def proxy_dict_items(iterator, readonly=False):
                 for key, value in iterator:
-                    yield (
-                        proxy(key, readonly=readonly),
-                        proxy(value, readonly=readonly),
-                    )
+                    yield key, proxy(value, readonly=readonly)
 
             return proxy_dict_items(iterator, readonly=self.readonly)
         else:

--- a/observ/observables.py
+++ b/observ/observables.py
@@ -202,7 +202,7 @@ class ProxiedItemsIterator:
 
     def __next__(self):
         if hasattr(self, "_iter"):
-            key, value = self._iter.__next__()  # .__next__()
+            key, value = self._iter.__next__()
         else:
             key, value = self.iterator.__next__()
         return (
@@ -371,7 +371,6 @@ trap_map_readonly = {
 def make_observable(proxy_cls, obj_cls, traps, trap_map):
     for trap_type, methods in traps.items():
         for method in methods:
-            # trap = trap_map[trap_type](method, proxy_cls, obj_cls)
             trap = trap_map[trap_type](method, obj_cls)
             setattr(proxy_cls, method, trap)
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -18,7 +18,7 @@ def traverse(obj):
     Recursively traverse the whole tree to make sure
     that all values have been 'get'
     """
-    return _traverse(obj, set())
+    _traverse(obj, set())
 
 
 def _traverse(obj, seen: set):

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -52,9 +52,7 @@ class WrongNumberOfArgumentsError(TypeError):
 
 
 class Watcher:
-    def __init__(
-        self, fn, sync=False, lazy=True, deep=False, callback=None, readonly=False
-    ) -> None:
+    def __init__(self, fn, sync=False, lazy=True, deep=False, callback=None) -> None:
         """
         sync: Ignore the scheduler
         lazy: Only reevalutate when value is requested
@@ -69,7 +67,6 @@ class Watcher:
         self.callback = callback
         self.deep = deep
         self.lazy = lazy
-        self.readonly = readonly
         self.dirty = self.lazy
         self.value = None if self.lazy else self.get()
         self._number_of_callback_args = None

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -52,7 +52,9 @@ class WrongNumberOfArgumentsError(TypeError):
 
 
 class Watcher:
-    def __init__(self, fn, sync=False, lazy=True, deep=False, callback=None) -> None:
+    def __init__(
+        self, fn, sync=False, lazy=True, deep=False, callback=None, readonly=False
+    ) -> None:
         """
         sync: Ignore the scheduler
         lazy: Only reevalutate when value is requested
@@ -67,6 +69,7 @@ class Watcher:
         self.callback = callback
         self.deep = deep
         self.lazy = lazy
+        self.readonly = readonly
         self.dirty = self.lazy
         self.value = None if self.lazy else self.get()
         self._number_of_callback_args = None

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -30,7 +30,7 @@ def _traverse(obj, seen: set):
         # list, set (and their proxies) and tuple
         val_iter = iter(obj)
     else:
-        val_iter = iter(())
+        return
     for v in val_iter:
         if isinstance(v, Container) and id(v) not in seen:
             _traverse(v, seen)

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -3,7 +3,7 @@ watchers perform dependency tracking via functions acting on
 observable datastructures, and optionally trigger callback when
 a change is detected.
 """
-from collections.abc import Container
+from collections.abc import Container, Mapping
 import inspect
 from itertools import count
 from typing import Any
@@ -14,14 +14,20 @@ from .scheduler import scheduler
 
 
 def traverse(obj):
-    _traverse(obj, set())
+    """
+    Recursively traverse the whole tree to make sure
+    that all values have been 'get'
+    """
+    return _traverse(obj, set())
 
 
-def _traverse(obj, seen):
+def _traverse(obj, seen: set):
     seen.add(id(obj))
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
+        # dict and DictProxies
         val_iter = iter(obj.values())
-    elif isinstance(obj, (list, tuple, set)):
+    elif isinstance(obj, Container):
+        # list, set (and their proxies) and tuple
         val_iter = iter(obj)
     else:
         val_iter = iter(())

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,6 +29,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports.entry-points-selectable"
+version = "1.1.0"
+description = "Compatibility shim providing selectable entry points for older implementations"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -66,7 +81,7 @@ webencodings = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.5.30"
+version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -74,7 +89,7 @@ python-versions = "*"
 
 [[package]]
 name = "cffi"
-version = "1.14.6"
+version = "1.15.0"
 description = "Foreign Function Interface for Python calling C code."
 category = "dev"
 optional = false
@@ -84,8 +99,16 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "charset-normalizer"
-version = "2.0.6"
+version = "2.0.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
@@ -96,7 +119,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.1"
+version = "8.0.3"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -116,18 +139,21 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "5.5"
+version = "6.0.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=3.6"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
-toml = ["toml"]
+toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "3.4.8"
+version = "35.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "dev"
 optional = false
@@ -140,9 +166,9 @@ cffi = ">=1.12"
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-sdist = ["setuptools-rust (>=0.11.4)"]
+sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "dataclasses"
@@ -153,6 +179,14 @@ optional = false
 python-versions = ">=3.6, <3.7"
 
 [[package]]
+name = "distlib"
+version = "0.3.3"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "docutils"
 version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -161,18 +195,30 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "filelock"
+version = "3.3.1"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
 name = "flake8"
-version = "3.9.2"
+version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
+pycodestyle = ">=2.8.0,<2.9.0"
+pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
 name = "flake8-black"
@@ -212,8 +258,19 @@ pycodestyle = "*"
 six = "*"
 
 [[package]]
+name = "identify"
+version = "2.3.1"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.extras]
+license = ["editdistance-s"]
+
+[[package]]
 name = "idna"
-version = "3.2"
+version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "dev"
 optional = false
@@ -221,7 +278,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.2.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -233,8 +290,22 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "importlib-resources"
+version = "5.3.0"
+description = "Read resources from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -291,6 +362,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.6.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
@@ -321,6 +400,18 @@ python-versions = "*"
 testing = ["nose", "coverage"]
 
 [[package]]
+name = "platformdirs"
+version = "2.4.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -336,6 +427,24 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pre-commit"
+version = "2.15.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -345,11 +454,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycodestyle"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycparser"
@@ -361,7 +470,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.3.1"
+version = "2.4.0"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
@@ -377,22 +486,25 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.1"
 description = "Python parsing module"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyside6"
-version = "6.1.3"
+version = "6.2.0"
 description = "Python bindings for the Qt cross-platform application and UI framework"
 category = "dev"
 optional = false
-python-versions = ">=3.6, <3.10"
+python-versions = ">=3.6, <3.11"
 
 [package.dependencies]
-shiboken6 = "6.1.3"
+shiboken6 = "6.2.0"
 
 [[package]]
 name = "pytest"
@@ -418,30 +530,29 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "pytest-cov"
-version = "2.12.1"
+version = "3.0.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-coverage = ">=5.2.1"
+coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
-toml = "*"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-timeout"
-version = "1.4.2"
-description = "py.test plugin to abort hanging tests"
+version = "2.0.1"
+description = "pytest plugin to abort hanging tests"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pytest = ">=3.6.0"
+pytest = ">=5.0.0"
 
 [[package]]
 name = "pywin32-ctypes"
@@ -452,8 +563,16 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "readme-renderer"
-version = "29.0"
+version = "30.0"
 description = "readme_renderer is a library for rendering \"readme\" descriptions for Warehouse"
 category = "dev"
 optional = false
@@ -463,14 +582,13 @@ python-versions = "*"
 bleach = ">=2.1.0"
 docutils = ">=0.13.1"
 Pygments = ">=2.5.1"
-six = "*"
 
 [package.extras]
-md = ["cmarkgfm (>=0.5.0,<0.6.0)"]
+md = ["cmarkgfm (>=0.5.0,<0.7.0)"]
 
 [[package]]
 name = "regex"
-version = "2021.9.24"
+version = "2021.10.23"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -530,11 +648,11 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "shiboken6"
-version = "6.1.3"
+version = "6.2.0"
 description = "Python / C++ bindings helper module"
 category = "dev"
 optional = false
-python-versions = ">=3.6, <3.10"
+python-versions = ">=3.6, <3.11"
 
 [[package]]
 name = "six"
@@ -551,6 +669,14 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.2"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "tqdm"
@@ -617,6 +743,27 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.9.0"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+"backports.entry-points-selectable" = ">=1.0.4"
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
@@ -626,7 +773,7 @@ python-versions = "*"
 
 [[package]]
 name = "zipp"
-version = "3.5.0"
+version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
@@ -639,7 +786,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<3.10"
-content-hash = "a4d90f381f24d8ac8994ed67858fda8e546f9715bc3ff11c6b201a931d912c2b"
+content-hash = "0e8b8053e0a6a19660176c15aa8081695ba79c728b4cd369494e4400a61089ba"
 
 [metadata.files]
 appdirs = [
@@ -654,6 +801,10 @@ attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
+"backports.entry-points-selectable" = [
+    {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
+    {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
+]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
@@ -662,152 +813,153 @@ bleach = [
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
 certifi = [
-    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
-    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 cffi = [
-    {file = "cffi-1.14.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:22b9c3c320171c108e903d61a3723b51e37aaa8c81255b5e7ce102775bd01e2c"},
-    {file = "cffi-1.14.6-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:f0c5d1acbfca6ebdd6b1e3eded8d261affb6ddcf2186205518f1428b8569bb99"},
-    {file = "cffi-1.14.6-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:99f27fefe34c37ba9875f224a8f36e31d744d8083e00f520f133cab79ad5e819"},
-    {file = "cffi-1.14.6-cp27-cp27m-win32.whl", hash = "sha256:55af55e32ae468e9946f741a5d51f9896da6b9bf0bbdd326843fec05c730eb20"},
-    {file = "cffi-1.14.6-cp27-cp27m-win_amd64.whl", hash = "sha256:7bcac9a2b4fdbed2c16fa5681356d7121ecabf041f18d97ed5b8e0dd38a80224"},
-    {file = "cffi-1.14.6-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ed38b924ce794e505647f7c331b22a693bee1538fdf46b0222c4717b42f744e7"},
-    {file = "cffi-1.14.6-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e22dcb48709fc51a7b58a927391b23ab37eb3737a98ac4338e2448bef8559b33"},
-    {file = "cffi-1.14.6-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:aedb15f0a5a5949ecb129a82b72b19df97bbbca024081ed2ef88bd5c0a610534"},
-    {file = "cffi-1.14.6-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:48916e459c54c4a70e52745639f1db524542140433599e13911b2f329834276a"},
-    {file = "cffi-1.14.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f627688813d0a4140153ff532537fbe4afea5a3dffce1f9deb7f91f848a832b5"},
-    {file = "cffi-1.14.6-cp35-cp35m-win32.whl", hash = "sha256:f0010c6f9d1a4011e429109fda55a225921e3206e7f62a0c22a35344bfd13cca"},
-    {file = "cffi-1.14.6-cp35-cp35m-win_amd64.whl", hash = "sha256:57e555a9feb4a8460415f1aac331a2dc833b1115284f7ded7278b54afc5bd218"},
-    {file = "cffi-1.14.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e8c6a99be100371dbb046880e7a282152aa5d6127ae01783e37662ef73850d8f"},
-    {file = "cffi-1.14.6-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:19ca0dbdeda3b2615421d54bef8985f72af6e0c47082a8d26122adac81a95872"},
-    {file = "cffi-1.14.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d950695ae4381ecd856bcaf2b1e866720e4ab9a1498cba61c602e56630ca7195"},
-    {file = "cffi-1.14.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9dc245e3ac69c92ee4c167fbdd7428ec1956d4e754223124991ef29eb57a09d"},
-    {file = "cffi-1.14.6-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8661b2ce9694ca01c529bfa204dbb144b275a31685a075ce123f12331be790b"},
-    {file = "cffi-1.14.6-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b315d709717a99f4b27b59b021e6207c64620790ca3e0bde636a6c7f14618abb"},
-    {file = "cffi-1.14.6-cp36-cp36m-win32.whl", hash = "sha256:80b06212075346b5546b0417b9f2bf467fea3bfe7352f781ffc05a8ab24ba14a"},
-    {file = "cffi-1.14.6-cp36-cp36m-win_amd64.whl", hash = "sha256:a9da7010cec5a12193d1af9872a00888f396aba3dc79186604a09ea3ee7c029e"},
-    {file = "cffi-1.14.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4373612d59c404baeb7cbd788a18b2b2a8331abcc84c3ba40051fcd18b17a4d5"},
-    {file = "cffi-1.14.6-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f10afb1004f102c7868ebfe91c28f4a712227fe4cb24974350ace1f90e1febbf"},
-    {file = "cffi-1.14.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fd4305f86f53dfd8cd3522269ed7fc34856a8ee3709a5e28b2836b2db9d4cd69"},
-    {file = "cffi-1.14.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d6169cb3c6c2ad50db5b868db6491a790300ade1ed5d1da29289d73bbe40b56"},
-    {file = "cffi-1.14.6-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d4b68e216fc65e9fe4f524c177b54964af043dde734807586cf5435af84045c"},
-    {file = "cffi-1.14.6-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33791e8a2dc2953f28b8d8d300dde42dd929ac28f974c4b4c6272cb2955cb762"},
-    {file = "cffi-1.14.6-cp37-cp37m-win32.whl", hash = "sha256:0c0591bee64e438883b0c92a7bed78f6290d40bf02e54c5bf0978eaf36061771"},
-    {file = "cffi-1.14.6-cp37-cp37m-win_amd64.whl", hash = "sha256:8eb687582ed7cd8c4bdbff3df6c0da443eb89c3c72e6e5dcdd9c81729712791a"},
-    {file = "cffi-1.14.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba6f2b3f452e150945d58f4badd92310449876c4c954836cfb1803bdd7b422f0"},
-    {file = "cffi-1.14.6-cp38-cp38-manylinux1_i686.whl", hash = "sha256:64fda793737bc4037521d4899be780534b9aea552eb673b9833b01f945904c2e"},
-    {file = "cffi-1.14.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9f3e33c28cd39d1b655ed1ba7247133b6f7fc16fa16887b120c0c670e35ce346"},
-    {file = "cffi-1.14.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26bb2549b72708c833f5abe62b756176022a7b9a7f689b571e74c8478ead51dc"},
-    {file = "cffi-1.14.6-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb687a11f0a7a1839719edd80f41e459cc5366857ecbed383ff376c4e3cc6afd"},
-    {file = "cffi-1.14.6-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2ad4d668a5c0645d281dcd17aff2be3212bc109b33814bbb15c4939f44181cc"},
-    {file = "cffi-1.14.6-cp38-cp38-win32.whl", hash = "sha256:487d63e1454627c8e47dd230025780e91869cfba4c753a74fda196a1f6ad6548"},
-    {file = "cffi-1.14.6-cp38-cp38-win_amd64.whl", hash = "sha256:c33d18eb6e6bc36f09d793c0dc58b0211fccc6ae5149b808da4a62660678b156"},
-    {file = "cffi-1.14.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:06c54a68935738d206570b20da5ef2b6b6d92b38ef3ec45c5422c0ebaf338d4d"},
-    {file = "cffi-1.14.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:f174135f5609428cc6e1b9090f9268f5c8935fddb1b25ccb8255a2d50de6789e"},
-    {file = "cffi-1.14.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f3ebe6e73c319340830a9b2825d32eb6d8475c1dac020b4f0aa774ee3b898d1c"},
-    {file = "cffi-1.14.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c8d896becff2fa653dc4438b54a5a25a971d1f4110b32bd3068db3722c80202"},
-    {file = "cffi-1.14.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4922cd707b25e623b902c86188aca466d3620892db76c0bdd7b99a3d5e61d35f"},
-    {file = "cffi-1.14.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c9e005e9bd57bc987764c32a1bee4364c44fdc11a3cc20a40b93b444984f2b87"},
-    {file = "cffi-1.14.6-cp39-cp39-win32.whl", hash = "sha256:eb9e2a346c5238a30a746893f23a9535e700f8192a68c07c0258e7ece6ff3728"},
-    {file = "cffi-1.14.6-cp39-cp39-win_amd64.whl", hash = "sha256:818014c754cd3dba7229c0f5884396264d51ffb87ec86e927ef0be140bfdb0d2"},
-    {file = "cffi-1.14.6.tar.gz", hash = "sha256:c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd"},
+    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
+    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
+    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
+    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
+    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
+    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
+    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
+    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
+    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
+    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
+    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
+    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
+    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
+    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
+    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
+    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
+    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.6.tar.gz", hash = "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"},
-    {file = "charset_normalizer-2.0.6-py3-none-any.whl", hash = "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6"},
+    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
+    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
 ]
 click = [
-    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
-    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
-    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
-    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
-    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
-    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
-    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
-    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
-    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
-    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
-    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
-    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
-    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
-    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
-    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
-    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
-    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
-    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
-    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
-    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
-    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
-    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
-    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
-    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
-    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
-    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
-    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
-    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
-    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
-    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
-    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
-    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
-    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
-    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
-    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
-    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
-    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
-    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+    {file = "coverage-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7"},
+    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd"},
+    {file = "coverage-6.0.2-cp310-cp310-win32.whl", hash = "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7"},
+    {file = "coverage-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d"},
+    {file = "coverage-6.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9"},
+    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2"},
+    {file = "coverage-6.0.2-cp36-cp36m-win32.whl", hash = "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122"},
+    {file = "coverage-6.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9"},
+    {file = "coverage-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc"},
+    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1"},
+    {file = "coverage-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330"},
+    {file = "coverage-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1"},
+    {file = "coverage-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc"},
+    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb"},
+    {file = "coverage-6.0.2-cp38-cp38-win32.whl", hash = "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f"},
+    {file = "coverage-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9"},
+    {file = "coverage-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0"},
+    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe"},
+    {file = "coverage-6.0.2-cp39-cp39-win32.whl", hash = "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce"},
+    {file = "coverage-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9"},
+    {file = "coverage-6.0.2-pp36-none-any.whl", hash = "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164"},
+    {file = "coverage-6.0.2-pp37-none-any.whl", hash = "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895"},
+    {file = "coverage-6.0.2.tar.gz", hash = "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149"},
 ]
 cryptography = [
-    {file = "cryptography-3.4.8-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14"},
-    {file = "cryptography-3.4.8-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7"},
-    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0a7dcbcd3f1913f664aca35d47c1331fce738d44ec34b7be8b9d332151b0b01e"},
-    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085"},
-    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b"},
-    {file = "cryptography-3.4.8-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb"},
-    {file = "cryptography-3.4.8-cp36-abi3-win32.whl", hash = "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7"},
-    {file = "cryptography-3.4.8-cp36-abi3-win_amd64.whl", hash = "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc"},
-    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5"},
-    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a305600e7a6b7b855cd798e00278161b681ad6e9b7eca94c721d5f588ab212af"},
-    {file = "cryptography-3.4.8-pp36-pypy36_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a"},
-    {file = "cryptography-3.4.8-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:d9ec0e67a14f9d1d48dd87a2531009a9b251c02ea42851c060b25c782516ff06"},
-    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498"},
-    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94fff993ee9bc1b2440d3b7243d488c6a3d9724cc2b09cdb297f6a886d040ef7"},
-    {file = "cryptography-3.4.8-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:8695456444f277af73a4877db9fc979849cd3ee74c198d04fc0776ebc3db52b9"},
-    {file = "cryptography-3.4.8-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:cd65b60cfe004790c795cc35f272e41a3df4631e2fb6b35aa7ac6ef2859d554e"},
-    {file = "cryptography-3.4.8.tar.gz", hash = "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"},
+    {file = "cryptography-35.0.0-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9"},
+    {file = "cryptography-35.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992"},
+    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6"},
+    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d"},
+    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6"},
+    {file = "cryptography-35.0.0-cp36-abi3-win32.whl", hash = "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8"},
+    {file = "cryptography-35.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6"},
+    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2"},
+    {file = "cryptography-35.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c"},
+    {file = "cryptography-35.0.0.tar.gz", hash = "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
+distlib = [
+    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
+    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
+]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
 ]
+filelock = [
+    {file = "filelock-3.3.1-py3-none-any.whl", hash = "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f"},
+    {file = "filelock-3.3.1.tar.gz", hash = "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"},
+]
 flake8 = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 flake8-black = [
     {file = "flake8-black-0.2.3.tar.gz", hash = "sha256:c199844bc1b559d91195ebe8620216f21ed67f2cc1ff6884294c91a0d2492684"},
@@ -821,13 +973,21 @@ flake8-print = [
     {file = "flake8-print-4.0.0.tar.gz", hash = "sha256:5afac374b7dc49aac2c36d04b5eb1d746d72e6f5df75a6ecaecd99e9f79c6516"},
     {file = "flake8_print-4.0.0-py3-none-any.whl", hash = "sha256:6c0efce658513169f96d7a24cf136c434dc711eb00ebd0a985eb1120103fe584"},
 ]
+identify = [
+    {file = "identify-2.3.1-py2.py3-none-any.whl", hash = "sha256:5a5000bd3293950d992843c0ef3d82b90a582de2161557bda7f493c8c8864f26"},
+    {file = "identify-2.3.1.tar.gz", hash = "sha256:8a92c56893e9a4ce951f09a50489986615e3eba7b4c60610e0b25f93ca4487ba"},
+]
 idna = [
-    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
-    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
+]
+importlib-resources = [
+    {file = "importlib_resources-5.3.0-py3-none-any.whl", hash = "sha256:7a65eb0d8ee98eedab76e6deb51195c67f8e575959f6356a6e15fd7e1148f2a3"},
+    {file = "importlib_resources-5.3.0.tar.gz", hash = "sha256:f2e58e721b505a79abe67f5868d99f8886aec8594c962c7490d0c22925f518da"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -849,6 +1009,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
@@ -861,101 +1025,139 @@ pkginfo = [
     {file = "pkginfo-1.7.1-py2.py3-none-any.whl", hash = "sha256:37ecd857b47e5f55949c41ed061eb51a0bee97a87c969219d144c0e023982779"},
     {file = "pkginfo-1.7.1.tar.gz", hash = "sha256:e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd"},
 ]
+platformdirs = [
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pre-commit = [
+    {file = "pre_commit-2.15.0-py2.py3-none-any.whl", hash = "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"},
+    {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 pygments = [
     {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},
     {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.1-py3-none-any.whl", hash = "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"},
+    {file = "pyparsing-3.0.1.tar.gz", hash = "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531"},
 ]
 pyside6 = [
-    {file = "PySide6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-abi3-macosx_10_14_x86_64.whl", hash = "sha256:619b6bb4a3e5451fe939983cb9f5155f2cded44c8449f60a1d250747a48f00f3"},
-    {file = "PySide6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-abi3-manylinux1_x86_64.whl", hash = "sha256:64d69fd2d38b47982c06619f9969b6ae5c632f21f8ff2432e4953b0179a21411"},
-    {file = "PySide6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-none-win_amd64.whl", hash = "sha256:cbbe1a2bacca737b3000a8a18b0ba389ca93106800b10acb93660c1a5b6bfdec"},
+    {file = "PySide6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_14_x86_64.whl", hash = "sha256:57c039dc188dd5465c8a605ffa364748ae397894ac18f6df2655252ad015c97b"},
+    {file = "PySide6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:f1b3c2992a3edbadb8b40734870ca6d6bd51b6f1678a7ec91839fad1fd0dbc91"},
+    {file = "PySide6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:e8d0427d7b20ec53c08a01f2563934b4342e78b87ed7e01596e147b18590b5c8"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
-    {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 pytest-timeout = [
-    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
-    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
+    {file = "pytest-timeout-2.0.1.tar.gz", hash = "sha256:a5ec4eceddb8ea726911848593d668594107e797621e97f93a1d1dbc6fbb9080"},
+    {file = "pytest_timeout-2.0.1-py3-none-any.whl", hash = "sha256:329bdea323d3e5bea4737070dd85a0d1021dbecb2da5342dc25284fdb929dff0"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
 ]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
 readme-renderer = [
-    {file = "readme_renderer-29.0-py2.py3-none-any.whl", hash = "sha256:63b4075c6698fcfa78e584930f07f39e05d46f3ec97f65006e430b595ca6348c"},
-    {file = "readme_renderer-29.0.tar.gz", hash = "sha256:92fd5ac2bf8677f310f3303aa4bce5b9d5f9f2094ab98c29f13791d7b805a3db"},
+    {file = "readme_renderer-30.0-py2.py3-none-any.whl", hash = "sha256:3286806450d9961d6e3b5f8a59f77e61503799aca5155c8d8d40359b4e1e1adc"},
+    {file = "readme_renderer-30.0.tar.gz", hash = "sha256:8299700d7a910c304072a7601eafada6712a5b011a20139417e1b1e9f04645d8"},
 ]
 regex = [
-    {file = "regex-2021.9.24-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0628ed7d6334e8f896f882a5c1240de8c4d9b0dd7c7fb8e9f4692f5684b7d656"},
-    {file = "regex-2021.9.24-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3baf3eaa41044d4ced2463fd5d23bf7bd4b03d68739c6c99a59ce1f95599a673"},
-    {file = "regex-2021.9.24-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c000635fd78400a558bd7a3c2981bb2a430005ebaa909d31e6e300719739a949"},
-    {file = "regex-2021.9.24-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:295bc8a13554a25ad31e44c4bedabd3c3e28bba027e4feeb9bb157647a2344a7"},
-    {file = "regex-2021.9.24-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0e3f59d3c772f2c3baaef2db425e6fc4149d35a052d874bb95ccfca10a1b9f4"},
-    {file = "regex-2021.9.24-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aea4006b73b555fc5bdb650a8b92cf486d678afa168cf9b38402bb60bf0f9c18"},
-    {file = "regex-2021.9.24-cp310-cp310-win32.whl", hash = "sha256:09eb62654030f39f3ba46bc6726bea464069c29d00a9709e28c9ee9623a8da4a"},
-    {file = "regex-2021.9.24-cp310-cp310-win_amd64.whl", hash = "sha256:8d80087320632457aefc73f686f66139801959bf5b066b4419b92be85be3543c"},
-    {file = "regex-2021.9.24-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7e3536f305f42ad6d31fc86636c54c7dafce8d634e56fef790fbacb59d499dd5"},
-    {file = "regex-2021.9.24-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c31f35a984caffb75f00a86852951a337540b44e4a22171354fb760cefa09346"},
-    {file = "regex-2021.9.24-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c7cb25adba814d5f419733fe565f3289d6fa629ab9e0b78f6dff5fa94ab0456"},
-    {file = "regex-2021.9.24-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:85c61bee5957e2d7be390392feac7e1d7abd3a49cbaed0c8cee1541b784c8561"},
-    {file = "regex-2021.9.24-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c94722bf403b8da744b7d0bb87e1f2529383003ceec92e754f768ef9323f69ad"},
-    {file = "regex-2021.9.24-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6adc1bd68f81968c9d249aab8c09cdc2cbe384bf2d2cb7f190f56875000cdc72"},
-    {file = "regex-2021.9.24-cp36-cp36m-win32.whl", hash = "sha256:2054dea683f1bda3a804fcfdb0c1c74821acb968093d0be16233873190d459e3"},
-    {file = "regex-2021.9.24-cp36-cp36m-win_amd64.whl", hash = "sha256:7783d89bd5413d183a38761fbc68279b984b9afcfbb39fa89d91f63763fbfb90"},
-    {file = "regex-2021.9.24-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b15dc34273aefe522df25096d5d087abc626e388a28a28ac75a4404bb7668736"},
-    {file = "regex-2021.9.24-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10a7a9cbe30bd90b7d9a1b4749ef20e13a3528e4215a2852be35784b6bd070f0"},
-    {file = "regex-2021.9.24-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb9f5844db480e2ef9fce3a72e71122dd010ab7b2920f777966ba25f7eb63819"},
-    {file = "regex-2021.9.24-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:17310b181902e0bb42b29c700e2c2346b8d81f26e900b1328f642e225c88bce1"},
-    {file = "regex-2021.9.24-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bba1f6df4eafe79db2ecf38835c2626dbd47911e0516f6962c806f83e7a99ae"},
-    {file = "regex-2021.9.24-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:821e10b73e0898544807a0692a276e539e5bafe0a055506a6882814b6a02c3ec"},
-    {file = "regex-2021.9.24-cp37-cp37m-win32.whl", hash = "sha256:9c371dd326289d85906c27ec2bc1dcdedd9d0be12b543d16e37bad35754bde48"},
-    {file = "regex-2021.9.24-cp37-cp37m-win_amd64.whl", hash = "sha256:1e8d1898d4fb817120a5f684363b30108d7b0b46c7261264b100d14ec90a70e7"},
-    {file = "regex-2021.9.24-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8a5c2250c0a74428fd5507ae8853706fdde0f23bfb62ee1ec9418eeacf216078"},
-    {file = "regex-2021.9.24-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8aec4b4da165c4a64ea80443c16e49e3b15df0f56c124ac5f2f8708a65a0eddc"},
-    {file = "regex-2021.9.24-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:650c4f1fc4273f4e783e1d8e8b51a3e2311c2488ba0fcae6425b1e2c248a189d"},
-    {file = "regex-2021.9.24-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2cdb3789736f91d0b3333ac54d12a7e4f9efbc98f53cb905d3496259a893a8b3"},
-    {file = "regex-2021.9.24-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e61100200fa6ab7c99b61476f9f9653962ae71b931391d0264acfb4d9527d9c"},
-    {file = "regex-2021.9.24-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8c268e78d175798cd71d29114b0a1f1391c7d011995267d3b62319ec1a4ecaa1"},
-    {file = "regex-2021.9.24-cp38-cp38-win32.whl", hash = "sha256:658e3477676009083422042c4bac2bdad77b696e932a3de001c42cc046f8eda2"},
-    {file = "regex-2021.9.24-cp38-cp38-win_amd64.whl", hash = "sha256:a731552729ee8ae9c546fb1c651c97bf5f759018fdd40d0e9b4d129e1e3a44c8"},
-    {file = "regex-2021.9.24-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:86f9931eb92e521809d4b64ec8514f18faa8e11e97d6c2d1afa1bcf6c20a8eab"},
-    {file = "regex-2021.9.24-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dcbbc9cfa147d55a577d285fd479b43103188855074552708df7acc31a476dd9"},
-    {file = "regex-2021.9.24-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29385c4dbb3f8b3a55ce13de6a97a3d21bd00de66acd7cdfc0b49cb2f08c906c"},
-    {file = "regex-2021.9.24-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c50a6379763c733562b1fee877372234d271e5c78cd13ade5f25978aa06744db"},
-    {file = "regex-2021.9.24-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f74b6d8f59f3cfb8237e25c532b11f794b96f5c89a6f4a25857d85f84fbef11"},
-    {file = "regex-2021.9.24-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6c4d83d21d23dd854ffbc8154cf293f4e43ba630aa9bd2539c899343d7f59da3"},
-    {file = "regex-2021.9.24-cp39-cp39-win32.whl", hash = "sha256:95e89a8558c8c48626dcffdf9c8abac26b7c251d352688e7ab9baf351e1c7da6"},
-    {file = "regex-2021.9.24-cp39-cp39-win_amd64.whl", hash = "sha256:835962f432bce92dc9bf22903d46c50003c8d11b1dc64084c8fae63bca98564a"},
-    {file = "regex-2021.9.24.tar.gz", hash = "sha256:6266fde576e12357b25096351aac2b4b880b0066263e7bc7a9a1b4307991bb0e"},
+    {file = "regex-2021.10.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d071dbe4b53c602edd87a7476ab23015a991374ddb228d941929ad7c8c922e"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34d870f9f27f2161709054d73646fc9aca49480617a65533fc2b4611c518e455"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fb698037c35109d3c2e30f2beb499e5ebae6e4bb8ff2e60c50b9a805a716f79"},
+    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cb46b542133999580ffb691baf67410306833ee1e4f58ed06b6a7aaf4e046952"},
+    {file = "regex-2021.10.23-cp310-cp310-win32.whl", hash = "sha256:5e9c9e0ce92f27cef79e28e877c6b6988c48b16942258f3bc55d39b5f911df4f"},
+    {file = "regex-2021.10.23-cp310-cp310-win_amd64.whl", hash = "sha256:ab7c5684ff3538b67df3f93d66bd3369b749087871ae3786e70ef39e601345b0"},
+    {file = "regex-2021.10.23-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de557502c3bec8e634246588a94e82f1ee1b9dfcfdc453267c4fb652ff531570"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee684f139c91e69fe09b8e83d18b4d63bf87d9440c1eb2eeb52ee851883b1b29"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5095a411c8479e715784a0c9236568ae72509450ee2226b649083730f3fadfc6"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b568809dca44cb75c8ebb260844ea98252c8c88396f9d203f5094e50a70355f"},
+    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eb672217f7bd640411cfc69756ce721d00ae600814708d35c930930f18e8029f"},
+    {file = "regex-2021.10.23-cp36-cp36m-win32.whl", hash = "sha256:a7a986c45d1099a5de766a15de7bee3840b1e0e1a344430926af08e5297cf666"},
+    {file = "regex-2021.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:6d7722136c6ed75caf84e1788df36397efdc5dbadab95e59c2bba82d4d808a4c"},
+    {file = "regex-2021.10.23-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f665677e46c5a4d288ece12fdedf4f4204a422bb28ff05f0e6b08b7447796d1"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:450dc27483548214314640c89a0f275dbc557968ed088da40bde7ef8fb52829e"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:129472cd06062fb13e7b4670a102951a3e655e9b91634432cfbdb7810af9d710"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a940ca7e7189d23da2bfbb38973832813eab6bd83f3bf89a977668c2f813deae"},
+    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:530fc2bbb3dc1ebb17f70f7b234f90a1dd43b1b489ea38cea7be95fb21cdb5c7"},
+    {file = "regex-2021.10.23-cp37-cp37m-win32.whl", hash = "sha256:ded0c4a3eee56b57fcb2315e40812b173cafe79d2f992d50015f4387445737fa"},
+    {file = "regex-2021.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:391703a2abf8013d95bae39145d26b4e21531ab82e22f26cd3a181ee2644c234"},
+    {file = "regex-2021.10.23-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be04739a27be55631069b348dda0c81d8ea9822b5da10b8019b789e42d1fe452"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ec99df95003f56edcd307db44f06fbeb708c4ccdcf940478067dd62353181e"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d1cdcda6bd16268316d5db1038965acf948f2a6f43acc2e0b1641ceab443623"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c186691a7995ef1db61205e00545bf161fb7b59cdb8c1201c89b333141c438a"},
+    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2b20f544cbbeffe171911f6ce90388ad36fe3fad26b7c7a35d4762817e9ea69c"},
+    {file = "regex-2021.10.23-cp38-cp38-win32.whl", hash = "sha256:c0938ddd60cc04e8f1faf7a14a166ac939aac703745bfcd8e8f20322a7373019"},
+    {file = "regex-2021.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:56f0c81c44638dfd0e2367df1a331b4ddf2e771366c4b9c5d9a473de75e3e1c7"},
+    {file = "regex-2021.10.23-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:80bb5d2e92b2258188e7dcae5b188c7bf868eafdf800ea6edd0fbfc029984a88"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1dae12321b31059a1a72aaa0e6ba30156fe7e633355e445451e4021b8e122b6"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1f2b59c28afc53973d22e7bc18428721ee8ca6079becf1b36571c42627321c65"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d134757a37d8640f3c0abb41f5e68b7cf66c644f54ef1cb0573b7ea1c63e1509"},
+    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0dcc0e71118be8c69252c207630faf13ca5e1b8583d57012aae191e7d6d28b84"},
+    {file = "regex-2021.10.23-cp39-cp39-win32.whl", hash = "sha256:a30513828180264294953cecd942202dfda64e85195ae36c265daf4052af0464"},
+    {file = "regex-2021.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:0f7552429dd39f70057ac5d0e897e5bfe211629652399a21671e53f2a9693a4e"},
+    {file = "regex-2021.10.23.tar.gz", hash = "sha256:f3f9a91d3cc5e5b0ddf1043c0ae5fa4852f18a1c0050318baf5fc7930ecc1f9c"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -974,9 +1176,9 @@ secretstorage = [
     {file = "SecretStorage-3.3.1.tar.gz", hash = "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"},
 ]
 shiboken6 = [
-    {file = "shiboken6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-abi3-macosx_10_14_x86_64.whl", hash = "sha256:7d285cb61dca4d543ea1ccd6f9bad1b555f222232dfc7240ebc7df83e21fb805"},
-    {file = "shiboken6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-abi3-manylinux1_x86_64.whl", hash = "sha256:c44d406263c1cbd1cb92efca02790c39b1563a25e888e3e5c7291aabd2363aee"},
-    {file = "shiboken6-6.1.3-6.1.3-cp36.cp37.cp38.cp39-none-win_amd64.whl", hash = "sha256:10023b1b6b27318db74a2232e808c8e5691ec1ff39be89d9878fc60e0adbb690"},
+    {file = "shiboken6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_14_x86_64.whl", hash = "sha256:8ccd10c9e21cb6e1e9135f706ea988c41494f7282cb869f5b2069b8142742865"},
+    {file = "shiboken6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:dce3b434d5d1be50b8920799647bbb2346dfd9331bf922425128085020097cb8"},
+    {file = "shiboken6-6.2.0-6.2.0-cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:44d32913baf698265f48a4d1072224ef6503bc49911b44dcfb48b103310ad643"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -985,6 +1187,10 @@ six = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
+    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
 ]
 tqdm = [
     {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},
@@ -1035,11 +1241,15 @@ urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
+virtualenv = [
+    {file = "virtualenv-20.9.0-py2.py3-none-any.whl", hash = "sha256:1d145deec2da86b29026be49c775cc5a9aab434f85f7efef98307fb3965165de"},
+    {file = "virtualenv-20.9.0.tar.gz", hash = "sha256:bb55ace18de14593947354e5e6cd1be75fb32c3329651da62e92bf5d0aab7213"},
+]
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 zipp = [
-    {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},
-    {file = "zipp-3.5.0.tar.gz", hash = "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"},
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ flake8 = "*"
 flake8-black = "*"
 flake8-import-order = "*"
 flake8-print = "*"
+pre-commit = { version = "*", python = ">=3.6.1"}
 pytest = "*"
 pytest-cov = "*"
 pytest-timeout = "*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from observ import scheduler
+from observ.observables import proxy_db
 
 
 def noop():
@@ -23,3 +24,8 @@ def clear():
         yield
     finally:
         scheduler.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_proxy_db():
+    proxy_db.db = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 
 from observ import scheduler
@@ -28,4 +30,10 @@ def clear():
 
 @pytest.fixture(autouse=True)
 def clear_proxy_db():
-    proxy_db.db = {}
+    # Would be nice to do this at the end of runs, but
+    # it seems that pytest keeps some references to some objects
+    # so we're not able to guarentee that the db can be
+    # cleared properly afterwards.
+    # Running gc at the beginning does actually work.
+    gc.collect()
+    assert len(proxy_db.db) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,8 @@ def clear_proxy_db():
     # it seems that pytest keeps some references to some objects
     # so we're not able to guarentee that the db can be
     # cleared properly afterwards.
-    # Running gc at the beginning does actually work.
     gc.collect()
-    assert len(proxy_db.db) == 0
+    # Running gc at the beginning should clear the proxy_db,
+    # but this apparently only works when tests are not failing,
+    # so the db needs to be cleared like this.
+    proxy_db.db = {}

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -15,6 +15,7 @@ COLLECTIONS = {
 WRAPATTRS = {
     "READERS",
     "KEYREADERS",
+    "ITERATORS",
     "WRITERS",
     "KEYWRITERS",
     "DELETERS",
@@ -59,7 +60,7 @@ def test_wrapping_complete():
         # ensure we're wrapping everything
         to_wrap = set(dir(coll)) - EXCLUDED
         wrapped = set(wrap_list)
-        assert to_wrap == wrapped
+        assert to_wrap == wrapped, f"Failing for: {coll}"
 
 
 def test_list_notify():

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,4 +1,4 @@
-from observ import computed, observe
+from observ import computed, reactive
 from observ.observables import proxy_db
 
 
@@ -6,7 +6,7 @@ def test_deps_copy():
     # this test proves that even though we have
     # redundant deps we don't redundantly recompute
     # FIXME: I don't think this test works as intended anymore
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     call_count = 0
 
     @computed
@@ -31,7 +31,7 @@ def test_deps_copy():
 
 def test_deps_delete():
     # test that dep objects are removed on delete
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
 
     state["baz"] = 5
     assert len(proxy_db.attrs(state)["keydep"]) == 3

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,9 +1,11 @@
 from observ import computed, observe
+from observ.observables import proxy_db
 
 
 def test_deps_copy():
-    # this test proves that even tho we have redundant deps
-    # we don't redundantly recompute
+    # this test proves that even though we have
+    # redundant deps we don't redundantly recompute
+    # FIXME: I don't think this test works as intended anymore
     state = observe({"foo": 5, "bar": 6})
     call_count = 0
 
@@ -15,13 +17,15 @@ def test_deps_copy():
 
     assert prop() == {"foo": 5, "bar": 6}
     assert prop() is not state
-    assert len(prop.__watcher__._deps) == 3
+    # FIXME: the _deps length was 3
+    assert len(prop.__watcher__._deps) == 1
     assert call_count == 1
 
     state["foo"] = 3
     assert prop() == {"foo": 3, "bar": 6}
     assert prop() is not state
-    assert len(prop.__watcher__._deps) == 3
+    # FIXME: the _deps length was 3
+    assert len(prop.__watcher__._deps) == 1
     assert call_count == 2
 
 
@@ -30,13 +34,13 @@ def test_deps_delete():
     state = observe({"foo": 5, "bar": 6})
 
     state["baz"] = 5
-    assert len(state.__keydeps__) == 3
+    assert len(proxy_db.attrs(state)["keydep"]) == 3
 
     del state["baz"]
-    assert len(state.__keydeps__) == 2
+    assert len(proxy_db.attrs(state)["keydep"]) == 2
 
     state.popitem()
-    assert len(state.__keydeps__) == 1
+    assert len(proxy_db.attrs(state)["keydep"]) == 1
 
     state.clear()
-    assert len(state.__keydeps__) == 0
+    assert len(proxy_db.attrs(state)["keydep"]) == 0

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -1,10 +1,10 @@
-from observ import computed, observe
+from observ import computed, reactive
 
 
 def test_observe_new_coll():
     # this test proves that even tho we have redundant deps
     # we don't redundantly recompute
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
 
     @computed
     def prop():
@@ -27,7 +27,7 @@ def test_observe_new_coll():
 def test_observe_changed():
     # this test proves that we only fire if a value actually
     # changed
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     call_count = 0
 
     @computed

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,6 +9,8 @@ from observ.observables import (
     proxy,
     proxy_db,
     ReadonlyDictProxy,
+    ReadonlyListProxy,
+    ReadonlySetProxy,
     ReadonlyError,
     SetProxy,
 )
@@ -142,8 +144,7 @@ def test_readonly_dict_proxy():
 
 
 def test_readonly_nested_dict_proxy():
-    data = {"foo": "bar"}
-    proxied = proxy(data)
+    proxied = proxy({"foo": "bar"})
     readonly_proxy = proxy(proxied, readonly=True)
     another_proxied = proxy(readonly_proxy, readonly=False)
 
@@ -154,6 +155,24 @@ def test_readonly_nested_dict_proxy():
         readonly_proxy["foo"] = "baz"
 
     another_proxied["foo"] = "baz"
+
+
+def test_readonly_list_proxy():
+    readonly_proxy = proxy(["foo", "bar"], readonly=True)
+
+    assert isinstance(readonly_proxy, ReadonlyListProxy)
+
+    with pytest.raises(ReadonlyError):
+        readonly_proxy[0] = "baz"
+
+
+def test_readonly_set_proxy():
+    readonly_proxy = proxy({"foo", "bar"}, readonly=True)
+
+    assert isinstance(readonly_proxy, ReadonlySetProxy)
+
+    with pytest.raises(ReadonlyError):
+        readonly_proxy.add("baz")
 
 
 def test_nested_dict_proxy():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -2,11 +2,13 @@ import pytest
 
 from observ.observables import (
     DictProxy,
+    ListProxy,
     Proxy,
     proxy,
     proxy_db,
     ReadonlyDictProxy,
     ReadonlyError,
+    SetProxy,
 )
 
 
@@ -51,6 +53,29 @@ def test_multiple_proxy_calls():
     assert second_proxy is third_proxy
 
 
+def test_list_proxy():
+    data = [1, 2, 3]
+    proxied = proxy(data)
+    assert isinstance(proxied, ListProxy)
+    assert proxied[0] == 1
+    assert len(proxied) == 3
+    assert 1 in proxied
+
+
+def test_list_proxy_deep():
+    data = [1, {"foo": "bar"}]
+    proxied = proxy(data)
+    assert isinstance(proxied[1], DictProxy)
+
+
+def test_set_proxy():
+    data = {1, 2, 3}
+    proxied = proxy(data)
+    assert isinstance(proxied, SetProxy)
+    assert len(proxied) == 3
+    assert 1 in proxied
+
+
 def test_dict_proxy():
     data = {"foo": "bar"}
 
@@ -79,3 +104,10 @@ def test_readonly_dict_proxy():
 
     with pytest.raises(ReadonlyError):
         readonly_proxy["foo"] = "baz"
+
+
+def test_nested_dict_proxy():
+    data = {"foo": "bar", "baz": {"lorem": "ipsum"}}
+    proxied = proxy(data)
+    assert isinstance(proxied, DictProxy)
+    assert isinstance(proxied["baz"], DictProxy)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -146,3 +146,17 @@ def test_nested_dict_proxy():
     proxied = proxy(data)
     assert isinstance(proxied, DictProxy)
     assert isinstance(proxied["baz"], DictProxy)
+
+
+def test_tuple():
+    data = ({"foo": "bar"},)
+    proxied = proxy(data)
+    assert isinstance(proxied, tuple)
+    assert isinstance(proxied[0], DictProxy)
+
+
+def test_embedded_tuple():
+    data = {"foo": ({"bar"},)}
+    proxied = proxy(data)
+    assert isinstance(proxied, DictProxy)
+    assert isinstance(proxied["foo"][0], SetProxy)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,4 @@
-from observ.observables import Proxy, proxy, proxy_db
+from observ.observables import DictProxy, Proxy, proxy, proxy_db
 
 
 def test_proxy():
@@ -10,13 +10,13 @@ def test_proxy():
 
     assert isinstance(wrapped_data, Proxy)
     assert obj_id in proxy_db.db
-    assert wrapped_data.obj is data
+    assert wrapped_data.target is data
 
     # Retrieve the proxy from the proxy_db
     referenced_proxy = proxy_db.get_proxy(data)
 
     assert referenced_proxy is wrapped_data
-    assert referenced_proxy.obj is wrapped_data.obj
+    assert referenced_proxy.target is wrapped_data.target
 
     # Destroy the second proxy
     del referenced_proxy
@@ -40,3 +40,23 @@ def test_multiple_proxy_calls():
 
     assert first_proxy is second_proxy
     assert second_proxy is third_proxy
+
+
+def test_dict_proxy():
+    data = {"foo": "bar"}
+
+    proxied = proxy(data)
+    assert isinstance(proxied, DictProxy)
+    assert proxied["foo"] == "bar"
+
+    proxied["foo"] = "baz"
+
+    assert proxied["foo"] == "baz"
+
+    proxied["lorem"] = "ipsum"
+
+    assert proxied["lorem"] == "ipsum"
+
+    del proxied["lorem"]
+    assert "lorem" not in proxied
+    assert len(proxied) == 1

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -184,3 +184,17 @@ def test_shallow_proxy():
 
     deep_proxy = proxy(shallow_proxy)
     assert not deep_proxy.shallow
+
+
+def test_non_hashable():
+    # Should not be able to create a hash from a proxy
+    with pytest.raises(TypeError):
+        hash(proxy({}))
+
+    # Should not be able to add a proxy to a set
+    with pytest.raises(TypeError):
+        _ = proxy({"set", proxy({})})
+
+    # Should not be able to use a proxy as a key
+    with pytest.raises(TypeError):
+        _ = proxy({proxy({}): "value"})

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 
 from observ.observables import (
@@ -12,7 +14,7 @@ from observ.observables import (
 )
 
 
-def test_proxy():
+def test_proxy_lifecycle():
     data = {"foo": "bar"}
     obj_id = id(data)
 
@@ -38,8 +40,14 @@ def test_proxy():
     # Destroy the original proxy
     del wrapped_data
 
-    assert obj_id not in proxy_db.db
+    assert obj_id in proxy_db.db
     assert proxy_db.get_proxy(data) is None
+
+    # Also delete the original data and run garbage collection
+    del data
+    gc.collect()
+
+    assert obj_id not in proxy_db.db
 
 
 def test_multiple_proxy_calls():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -50,6 +50,33 @@ def test_proxy_lifecycle():
     assert obj_id not in proxy_db.db
 
 
+def test_proxy_lifecycle_auto():
+    # Call proxy to wrap the data object
+    wrapped_data = proxy({"foo": "bar"})
+    obj_id = id(wrapped_data.target)
+
+    assert isinstance(wrapped_data, Proxy)
+    assert obj_id in proxy_db.db
+    # assert wrapped_data.target is data
+
+    # Retrieve the proxy from the proxy_db
+    referenced_proxy = proxy_db.get_proxy(wrapped_data.target)
+
+    assert referenced_proxy is wrapped_data
+    assert referenced_proxy.target is wrapped_data.target
+
+    # Destroy the second proxy
+    del referenced_proxy
+
+    assert obj_id in proxy_db.db
+    assert proxy_db.get_proxy(wrapped_data.target) is not None
+
+    # Destroy the original proxy
+    del wrapped_data
+
+    assert obj_id not in proxy_db.db
+
+
 def test_multiple_proxy_calls():
     data = {"foo": "bar"}
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,9 +9,9 @@ from observ.observables import (
     proxy,
     proxy_db,
     ReadonlyDictProxy,
+    ReadonlyError,
     ReadonlyListProxy,
     ReadonlySetProxy,
-    ReadonlyError,
     SetProxy,
 )
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,13 @@
-from observ.observables import DictProxy, Proxy, proxy, proxy_db
+import pytest
+
+from observ.observables import (
+    DictProxy,
+    Proxy,
+    proxy,
+    proxy_db,
+    ReadonlyDictProxy,
+    ReadonlyError,
+)
 
 
 def test_proxy():
@@ -60,3 +69,13 @@ def test_dict_proxy():
     del proxied["lorem"]
     assert "lorem" not in proxied
     assert len(proxied) == 1
+
+
+def test_readonly_dict_proxy():
+    data = {"foo": "bar"}
+    readonly_proxy = proxy(data, readonly=True)
+
+    assert isinstance(readonly_proxy, ReadonlyDictProxy)
+
+    with pytest.raises(ReadonlyError):
+        readonly_proxy["foo"] = "baz"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -217,3 +217,12 @@ def test_non_hashable():
     # Should not be able to use a proxy as a key
     with pytest.raises(TypeError):
         _ = proxy({proxy({}): "value"})
+
+
+def test_raise_on_existing_proxy():
+    data = {"foo": "bar"}
+
+    _ = Proxy(data)
+
+    with pytest.raises(RuntimeError):
+        _ = Proxy(data)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -141,6 +141,21 @@ def test_readonly_dict_proxy():
         readonly_proxy["foo"] = "baz"
 
 
+def test_readonly_nested_dict_proxy():
+    data = {"foo": "bar"}
+    proxied = proxy(data)
+    readonly_proxy = proxy(proxied, readonly=True)
+    another_proxied = proxy(readonly_proxy, readonly=False)
+
+    assert isinstance(proxied, DictProxy)
+    assert isinstance(readonly_proxy, ReadonlyDictProxy)
+
+    with pytest.raises(ReadonlyError):
+        readonly_proxy["foo"] = "baz"
+
+    another_proxied["foo"] = "baz"
+
+
 def test_nested_dict_proxy():
     data = {"foo": "bar", "baz": {"lorem": "ipsum"}}
     proxied = proxy(data)
@@ -160,3 +175,12 @@ def test_embedded_tuple():
     proxied = proxy(data)
     assert isinstance(proxied, DictProxy)
     assert isinstance(proxied["foo"][0], SetProxy)
+
+
+def test_shallow_proxy():
+    shallow_proxy = proxy({"foo": "bar", "baz": {"lorem": "ipsum"}}, shallow=True)
+    assert isinstance(shallow_proxy, DictProxy)
+    assert shallow_proxy.shallow
+
+    deep_proxy = proxy(shallow_proxy)
+    assert not deep_proxy.shallow

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,42 @@
+from observ.observables import Proxy, proxy, proxy_db
+
+
+def test_proxy():
+    data = {"foo": "bar"}
+    obj_id = id(data)
+
+    # Call proxy to wrap the data object
+    wrapped_data = proxy(data)
+
+    assert isinstance(wrapped_data, Proxy)
+    assert obj_id in proxy_db.db
+    assert wrapped_data.obj is data
+
+    # Retrieve the proxy from the proxy_db
+    referenced_proxy = proxy_db.get_proxy(data)
+
+    assert referenced_proxy is wrapped_data
+    assert referenced_proxy.obj is wrapped_data.obj
+
+    # Destroy the second proxy
+    del referenced_proxy
+
+    assert obj_id in proxy_db.db
+    assert proxy_db.get_proxy(data) is not None
+
+    # Destroy the original proxy
+    del wrapped_data
+
+    assert obj_id not in proxy_db.db
+    assert proxy_db.get_proxy(data) is None
+
+
+def test_multiple_proxy_calls():
+    data = {"foo": "bar"}
+
+    first_proxy = proxy(data)
+    second_proxy = proxy(data)
+    third_proxy = proxy(second_proxy)
+
+    assert first_proxy is second_proxy
+    assert second_proxy is third_proxy

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,13 +1,13 @@
 import pytest
 
-from observ import observe, scheduler, watch
+from observ import reactive, scheduler, watch
 
 
 def test_no_flush_handler():
     """
     Test if we get a ValueError when no flush request handler is registered
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
     def cb(old, new):
@@ -24,7 +24,7 @@ def test_flush(noop_request_flush):
     """
     Test if flush works
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
     def cb(old, new):
@@ -51,7 +51,7 @@ def test_cycle_expression(noop_request_flush):
     Test if we can detect an infinite update cycle caused by
     the watch expression
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
     def exp():
@@ -79,7 +79,7 @@ def test_cycle_callback(noop_request_flush):
     Test if we can detect an infinite update cycle caused
     by a callback
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
     def exp():
@@ -107,7 +107,7 @@ def test_queue_growth(noop_request_flush):
     Test if a flush also handles watchers that are triggered
     during the flush
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls_1 = 0
     calls_2 = 0
 
@@ -143,7 +143,7 @@ def test_queue_cycle_indirect(noop_request_flush):
     Test if we can detect an infinite update cycle between
     _multiple_ watchers' callbacks
     """
-    state = observe({"foo": 5, "bar": 6})
+    state = reactive({"foo": 5, "bar": 6})
     calls_1 = 0
     calls_2 = 0
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -55,10 +55,10 @@ def test_cycle_expression(noop_request_flush):
     calls = 0
 
     def exp():
-        state["foo"] += 1
         return state["foo"]
 
     def cb(old, new):
+        state["foo"] += 1
         nonlocal calls
         calls += 1
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,7 +1,7 @@
 import pytest
 
 from observ import computed, reactive, to_raw, watch
-from observ.observables import Proxy, ReadonlyError, StateModifiedError
+from observ.observables import Proxy, StateModifiedError
 from observ.watcher import WrongNumberOfArgumentsError
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -403,6 +403,7 @@ def test_computed():
     def _expr_with_write():
         # Writing to the state during a computed
         # expression should raise a ReadonlyError
+        # Trigger a key writer
         a["bar"] = a["foo"] * 2
         return a["foo"] * 2
 
@@ -420,8 +421,29 @@ def test_watch_computed():
     @computed
     def _times_ten():
         # This next line should trigger the ReadonlyError
+        # Trigger a writer
         a.append(0)
         return a[0] * 10
 
     with pytest.raises(ReadonlyError):
         _ = watch(_times_ten, callback=None, sync=True)
+
+    a = reactive({"foo": "bar"})
+
+    @computed
+    def _comp_fail():
+        # Trigger a key deleter
+        a.pop()
+        return a[0]
+
+    with pytest.raises(ReadonlyError):
+        _ = watch(_comp_fail, None, sync=True)
+
+    @computed
+    def _comp_fail():
+        # Trigger a deleter
+        a.clear()
+        return a[0]
+
+    with pytest.raises(ReadonlyError):
+        _ = watch(_comp_fail, None, sync=True)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -326,4 +326,5 @@ def test_isinstance():
 
     assert len(calls) == 1
     # fails because our proxies don't pass the isinstance test
+    # unclear if we _want_ them to pass?
     assert isinstance(watcher.value, Proxy)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,6 +1,6 @@
 import pytest
 
-from observ import computed, reactive, watch
+from observ import computed, reactive, to_raw, watch
 from observ.observables import Proxy
 from observ.watcher import WrongNumberOfArgumentsError
 
@@ -76,7 +76,7 @@ def test_usage_set():
     assert len(a) == 3
 
 
-def test_usage():
+def test_usage_computed():
     a = reactive({"foo": 5, "bar": [6, 7, 8], "quux": 10, "quuz": {"a": 1, "b": 2}})
     execute_count = 0
 
@@ -364,3 +364,28 @@ def test_isinstance():
 
     assert len(calls) == 1
     assert isinstance(watcher.value, Proxy), type(watcher.value)
+
+
+def test_reactive_in_reactive():
+    state = reactive({"foo": 5})
+    state["bar"] = reactive(["something", "else"])
+
+    assert state["bar"][0] == "something"
+
+
+def test_to_raw():
+    state = reactive({"dict": {"key": 5}})
+    state["list"] = reactive(["list", "item"])
+    state["list"].append(reactive({"set"}))
+    state["tuple"] = (reactive({"set", "bloeb"}), reactive({"dict": "value"}))
+
+    raw = to_raw(state)
+
+    assert isinstance(raw, dict)
+    assert isinstance(raw["dict"], dict)
+    assert isinstance(raw["dict"]["key"], int), type(raw["dict"]["key"])
+    assert isinstance(raw["list"], list), type(raw["list"])
+    assert isinstance(raw["list"][-1], set), type(raw["list"][-1])
+    assert isinstance(raw["tuple"], tuple), type(raw["tuple"])
+    assert isinstance(raw["tuple"][0], set), type(raw["tuple"][0])
+    assert isinstance(raw["tuple"][1], dict), type(raw["tuple"][1])

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,12 +1,12 @@
 import pytest
 
-from observ import computed, observe, watch
+from observ import computed, reactive, watch
 from observ.observables import Proxy
 from observ.watcher import WrongNumberOfArgumentsError
 
 
 def test_usage_dict():
-    a = observe({"foo": "bar"})
+    a = reactive({"foo": "bar"})
     called = 0
     values = ()
 
@@ -27,7 +27,7 @@ def test_usage_dict():
 
 
 def test_usage_dict_new_key():
-    a = observe({"foo": "bar"})
+    a = reactive({"foo": "bar"})
     called = 0
 
     def _callback(new, old):
@@ -45,7 +45,7 @@ def test_usage_dict_new_key():
 
 
 def test_usage_list():
-    a = observe([1, 2])
+    a = reactive([1, 2])
     called = 0
 
     def _callback():
@@ -61,7 +61,7 @@ def test_usage_list():
 
 
 def test_usage_set():
-    a = observe({1, 2})
+    a = reactive({1, 2})
     called = 0
 
     def _callback():
@@ -77,7 +77,7 @@ def test_usage_set():
 
 
 def test_usage():
-    a = observe({"foo": 5, "bar": [6, 7, 8], "quux": 10, "quuz": {"a": 1, "b": 2}})
+    a = reactive({"foo": 5, "bar": [6, 7, 8], "quux": 10, "quuz": {"a": 1, "b": 2}})
     execute_count = 0
 
     def bla():
@@ -142,7 +142,7 @@ def test_usage():
 
 
 def test_watch_immediate():
-    a = observe({"foo": 5, "bar": [6, 7, 8], "quux": 10, "quuz": {"a": 1, "b": 2}})
+    a = reactive({"foo": 5, "bar": [6, 7, 8], "quux": 10, "quuz": {"a": 1, "b": 2}})
 
     called = 0
 
@@ -161,7 +161,7 @@ def test_watch_immediate():
 
 
 def test_usage_deep_vs_non_deep():
-    a = observe({"foo": [0, 1]})
+    a = reactive({"foo": [0, 1]})
 
     non_deep_called = 0
 
@@ -186,7 +186,7 @@ def test_usage_deep_vs_non_deep():
 
 
 def test_callback_signatures():
-    a = observe({"foo": 0})
+    a = reactive({"foo": 0})
     called = 0
 
     def empty_callback():
@@ -239,7 +239,7 @@ def test_callback_signatures():
 
 
 def test_dict_keys():
-    state = observe({"foo": {"bar": 5}})
+    state = reactive({"foo": {"bar": 5}})
 
     calls = []
 
@@ -262,7 +262,7 @@ def test_dict_keys():
 
 
 def test_dict_values():
-    state = observe({"foo": {"bar": 5}})
+    state = reactive({"foo": {"bar": 5}})
 
     calls = []
 
@@ -284,7 +284,7 @@ def test_dict_values():
 
 
 def test_dict_items():
-    state = observe({"foo": {"bar": 5}})
+    state = reactive({"foo": {"bar": 5}})
 
     calls = []
 
@@ -306,7 +306,7 @@ def test_dict_items():
 
 
 def test_list_iter():
-    state = observe([{"b": 5}])
+    state = reactive([{"b": 5}])
 
     calls = []
 
@@ -327,7 +327,7 @@ def test_list_iter():
 
 
 def test_list_reversed():
-    state = observe([{"b": 5}])
+    state = reactive([{"b": 5}])
 
     calls = []
 
@@ -348,7 +348,7 @@ def test_list_reversed():
 
 
 def test_isinstance():
-    state = observe(["a", {"b": 5}])
+    state = reactive(["a", {"b": 5}])
 
     calls = []
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -391,6 +391,7 @@ def test_to_raw():
     assert isinstance(raw["tuple"][1], dict), type(raw["tuple"][1])
 
 
+@pytest.mark.xfail
 def test_computed():
     a = reactive({"foo": 5})
 
@@ -406,5 +407,6 @@ def test_computed():
         a["bar"] = a["foo"] * 2
         return a["foo"] * 2
 
+    computed_expr = computed(_expr_with_write)
     with pytest.raises(ReadonlyError):
-        _ = computed(_expr_with_write)
+        _ = computed_expr()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -391,7 +391,6 @@ def test_to_raw():
     assert isinstance(raw["tuple"][1], dict), type(raw["tuple"][1])
 
 
-@pytest.mark.xfail
 def test_computed():
     a = reactive({"foo": 5})
 
@@ -410,3 +409,19 @@ def test_computed():
     computed_expr = computed(_expr_with_write)
     with pytest.raises(ReadonlyError):
         _ = computed_expr()
+
+
+def test_watch_computed():
+    a = reactive([0])
+    from observ.observables import ListProxy
+
+    assert isinstance(a, ListProxy)
+
+    @computed
+    def _times_ten():
+        # This next line should trigger the ReadonlyError
+        a.append(0)
+        return a[0] * 10
+
+    with pytest.raises(ReadonlyError):
+        _ = watch(_times_ten, callback=None, sync=True)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -238,7 +238,7 @@ def test_callback_signatures():
     assert not isinstance(e, WrongNumberOfArgumentsError)
 
 
-def test_dict_iter():
+def test_dict_items():
     state = observe({"foo": {"bar": 5}})
 
     calls = []
@@ -255,9 +255,75 @@ def test_dict_iter():
     watcher = watch(_expr, _called, sync=True, immediate=True, deep=True)
 
     assert len(calls) == 1
-    assert isinstance(state, Proxy)
 
-    # fails because the value is not wrapped
+    # fails because items is not proxied and thus
+    # the value is not wrapped
     state["foo"]["bar"] += 1
     assert len(calls) == 2
+    assert isinstance(watcher.value, Proxy)
+
+
+def test_list_iter():
+    state = observe([{"b": 5}])
+
+    calls = []
+
+    def _called(new):
+        nonlocal calls
+        calls.append(new)
+
+    def _expr():
+        for x in state:
+            return x["b"]
+
+    watcher = watch(_expr, _called, sync=True, immediate=True)
+
+    assert len(calls) == 1
+
+    # fails because __iter__ is not proxied and thus
+    # the value is not wrapped
+    state[0]["b"] = 6
+    assert len(calls) == 2
+
+
+def test_list_reversed():
+    state = observe([{"b": 5}])
+
+    calls = []
+
+    def _called(new):
+        nonlocal calls
+        calls.append(new)
+
+    def _expr():
+        for x in reversed(state):
+            return x["b"]
+
+    watcher = watch(_expr, _called, sync=True, immediate=True, deep=True)
+
+    assert len(calls) == 1
+
+    # fails because __reversed__ is not proxied and thus
+    # the value is not wrapped
+    state[0]["b"] = 6
+    assert len(calls) == 2
+
+
+def test_isinstance():
+    state = observe(["a", {"b": 5}])
+
+    calls = []
+
+    def _called(new):
+        nonlocal calls
+        calls.append(new)
+
+    def _expr():
+        if isinstance(state[1], dict):
+            return state[1]
+
+    watcher = watch(_expr, _called, sync=True, immediate=True)
+
+    assert len(calls) == 1
+    # fails because our proxies don't pass the isinstance test
     assert isinstance(watcher.value, Proxy)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -252,7 +252,7 @@ def test_dict_iter():
             if key == "foo":
                 return value
 
-    watcher = watch(_expr, _called, sync=True, immediate=True)
+    watcher = watch(_expr, _called, sync=True, immediate=True, deep=True)
 
     assert len(calls) == 1
     assert isinstance(state, Proxy)


### PR DESCRIPTION
Closes #23
Closes #16

This PR changes the reactivity mechanism so that you can have multiple proxy references to a single object, and such that objects are proxied lazily. This is based on Vue 3's approach, and allows for readonly proxies.

- [x] toRaw equivalent
- [x] verify readonly proxies
- [x] use readonly proxies for computed
- [x] documentation of caveats (i.e. gc)
- [x] update README