### PR TITLE
Fix update and __ior__ methods of dict

### DIFF
--- a/observ/observables.py
+++ b/observ/observables.py
@@ -253,7 +253,37 @@ def write_trap(method, obj_cls):
             raise StateModifiedError()
         args = tuple(proxy(a) for a in args)
         kwargs = {k: proxy(v) for k, v in kwargs.items()}
+
+        old_keys = set()
+        updated_keys = set()
+        if obj_cls == dict:
+            """
+            From the docs about `update` (__ior__ just accepts other dicts):
+            update() accepts either another dictionary object or an iterable
+            of key/value pairs (as tuples or other iterables of length two).
+            If keyword arguments are specified, the dictionary is then updated
+            with those key/value pairs: d.update(red=1, blue=2).
+            """
+            old_keys = set(self.target.keys())
+            if args:
+                if hasattr(args[0], "keys"):
+                    # First argument is (wrapped) dict
+                    updated_keys = set(args[0].keys())
+                else:
+                    # First argument is iterable of key/value pairs
+                    updated_keys = set(key for key, _ in args[0])
+            elif len(kwargs) > 0:
+                # Key/value pairs as keyword arguments
+                updated_keys = set(kwargs.keys())
         retval = fn(self.target, *args, **kwargs)
+        new_keys = updated_keys - old_keys
+        updated_keys &= old_keys
+
+        for key in new_keys:
+            proxy_db.attrs(self)["keydep"][key] = Dep()
+        for key in updated_keys:
+            proxy_db.attrs(self)["keydep"][key].notify()
+
         # TODO: prevent firing if value hasn't actually changed?
         proxy_db.attrs(self)["dep"].notify()
         return retval

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -200,12 +200,13 @@ def test_dict_notify():
     }
     for name in COLLECTIONS[DictProxy]["WRITERS"]:
         coll = DictProxy({2: 3})
+        old_keys = set(coll.keys())
         proxy_db.attrs(coll)["dep"].notify = Mock()
         for key in proxy_db.attrs(coll)["keydep"].keys():
             proxy_db.attrs(coll)["keydep"][key].notify = Mock()
         getattr(coll, name)(*args[name])
         proxy_db.attrs(coll)["dep"].notify.assert_called_once()
-        for key in proxy_db.attrs(coll)["keydep"].keys():
+        for key in old_keys:
             proxy_db.attrs(coll)["keydep"][key].notify.assert_not_called()
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -305,7 +305,7 @@ def test_dict_items():
     assert len(calls) == 2
 
 
-def test_dict_update():
+def test_dict_update_same_key():
     state = reactive({"foo": "bar"})
     called = 0
 
@@ -313,7 +313,7 @@ def test_dict_update():
         nonlocal called
         called += 1
 
-    _ = watch(lambda: state["foo"], _expr, sync=True, immediate=True)
+    _ = watch(lambda: state["foo"], _expr, sync=True, immediate=True, deep=True)
 
     assert called == 1
     assert state["foo"] == "bar"
@@ -321,7 +321,27 @@ def test_dict_update():
     state.update({"foo": "baz"})
 
     assert state["foo"] == "baz"
-    assert called == 2, state
+    assert called == 2
+
+
+def test_dict_update_new_keys():
+    state = reactive({"foo": "bar"})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: state["foo"], _expr, sync=True, immediate=True, deep=True)
+
+    assert called == 1
+    assert state["foo"] == "bar"
+
+    state.update({"foo": "baz", "bar": "foo"})
+
+    assert state["foo"] == "baz"
+    assert state["bar"] == "foo"
+    assert called == 2
 
 
 def test_list_iter():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -343,6 +343,18 @@ def test_dict_update_new_keys():
     assert state["bar"] == "foo"
     assert called == 2
 
+    state.update(foo="bar", baz="fool")
+
+    assert state["foo"] == "bar"
+    assert state["baz"] == "fool"
+    assert called == 3
+
+    state.update([("foo", "bas"), ("bat", "flat")])
+
+    assert state["foo"] == "bas"
+    assert state["bat"] == "flat"
+    assert called == 4
+
 
 def test_list_iter():
     state = reactive([{"b": 5}])

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -305,6 +305,25 @@ def test_dict_items():
     assert len(calls) == 2
 
 
+def test_dict_update():
+    state = reactive({"foo": "bar"})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: state["foo"], _expr, sync=True, immediate=True)
+
+    assert called == 1
+    assert state["foo"] == "bar"
+
+    state.update({"foo": "baz"})
+
+    assert state["foo"] == "baz"
+    assert called == 2, state
+
+
 def test_list_iter():
     state = reactive([{"b": 5}])
 


### PR DESCRIPTION
Apparently `update` and `__ior__` were broken, because no dependencies for updated keys were notified.

I added a check in the write_trap to see if it is a dict, and then figure out which keys are affected. Might instead just create a different `write_trap` function just for dict.