### PR TITLE
Refactor the store to make mutations nicer

### DIFF
--- a/examples/store_with_undo_redo.py
+++ b/examples/store_with_undo_redo.py
@@ -8,20 +8,20 @@ from observ.store import computed, mutation, Store
 
 class CounterStore(Store):
     @mutation
-    def bump_count(self, state):
+    def bump_count(self):
         """
         Bump counter by one.
 
-        Note: don't pass in the state argument: that is taken
-        care of by the store. By decorating it with `mutation`
-        the store wraps this method and passes in a writable
-        version of the state.
+        Note: normally self.state is a readonly proxy on the present
+        state, but because this method is decorated with `mutation`
+        `self.state` is replaced with the mutatable `self._present`
+        for the scope of this method to record any changes.
         """
-        state["count"] += 1
+        self.state["count"] += 1
 
     @mutation
-    def adjust_count(self, state, amount):
-        state["count"] = amount
+    def adjust_count(self, amount):
+        self.state["count"] = amount
 
     @computed
     def count(self):

--- a/examples/store_with_undo_redo.py
+++ b/examples/store_with_undo_redo.py
@@ -14,7 +14,7 @@ class CounterStore(Store):
 
         Note: normally self.state is a readonly proxy on the present
         state, but because this method is decorated with `mutation`
-        `self.state` is replaced with the mutatable `self._present`
+        `self.state` is replaced with the mutable `self._present`
         for the scope of this method to record any changes.
         """
         self.state["count"] += 1
@@ -43,7 +43,6 @@ if __name__ == "__main__":
     )
 
     # Bump the count by one
-    # Note that no state argument is provided here!
     store.bump_count()
     # Current state of the store can be accessed through
     # the `state` property on store
@@ -53,7 +52,6 @@ if __name__ == "__main__":
     assert store.count == 1
 
     # Set the count to 5
-    # Again, no state argument, just the amount
     store.adjust_count(5)
     assert store.count == 5
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,8 +8,8 @@ from observ.store import computed, mutation, Store
 
 class CustomStore(Store):
     @mutation
-    def bump_count(self, state):
-        state["count"] += 1
+    def bump_count(self):
+        self.state["count"] += 1
 
     @computed
     def double(self):


### PR DESCRIPTION
Instead of:
```python
class MyStore(Store):
    @mutation
    def add(self, state, amount):
        state["counter"] += amount
```
we can do:
```python
class MyStore(Store):
    @mutation
    def add(self, amount):
        self.state["counter"] += amount
```
So mutations look and read more like proper functions.