### PR TITLE
Fix real deep watchers

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -3,7 +3,7 @@ watchers perform dependency tracking via functions acting on
 observable datastructures, and optionally trigger callback when
 a change is detected.
 """
-from collections.abc import Container, Mapping
+from collections.abc import Container
 from functools import wraps
 import inspect
 from itertools import count
@@ -11,6 +11,7 @@ from typing import Any, Callable, Optional, TypeVar
 from weakref import WeakSet
 
 from .dep import Dep
+from .observables import DictProxyBase, ListProxyBase, SetProxyBase
 from .scheduler import scheduler
 
 
@@ -64,11 +65,9 @@ def traverse(obj):
 
 def _traverse(obj, seen: set):
     seen.add(id(obj))
-    if isinstance(obj, Mapping):
-        # dict and DictProxies
+    if isinstance(obj, (dict, DictProxyBase)):
         val_iter = iter(obj.values())
-    elif isinstance(obj, Container):
-        # list, set (and their proxies) and tuple
+    elif isinstance(obj, (list, ListProxyBase, set, SetProxyBase, tuple)):
         val_iter = iter(obj)
     else:
         return

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -525,3 +525,27 @@ def test_computed_deep():
 
     a["items"] = []
     shallow_watcher.callback.assert_called_once()
+
+
+def test_watch_real_deep():
+    from observ.observables import ListProxy
+
+    a = reactive({"scene": {"objects": {"camera": {"position": [0, 0, 0]}}}})
+
+    watcher = watch(
+        lambda: a["scene"],
+        Mock(),
+        sync=True,
+        deep=True,
+    )
+
+    watcher.callback.assert_not_called()
+    a["scene"]["objects"]["camera"]["position"] = [0, 1, 0]
+    watcher.callback.assert_called_once()
+
+    assert isinstance(a["scene"]["objects"]["camera"]["position"], ListProxy)
+    assert not a["scene"]["objects"]["camera"]["position"].shallow
+
+    watcher.callback = Mock()
+    a["scene"]["objects"]["camera"]["position"][1] = 2
+    watcher.callback.assert_called_once()


### PR DESCRIPTION
I had a problem with some changes deep within some structures not coming through.
Apparently, a `DictProxy` is *not* an instance of `Mapping`... And the same goes for the other proxies. I thought I had tried and tested this before (in a REPL I believe), but I must have done something weird.

Anyways, I've updated `traverse` with checking for the specific types that we support and now it all seems to work as intended!