### PR TITLE
Make computed deep by default

### DIFF
--- a/observ/store.py
+++ b/observ/store.py
@@ -32,7 +32,7 @@ def mutation(fn: T) -> T:
     return inner
 
 
-def computed(_fn=None, *, deep=False):
+def computed(_fn=None, *, deep=True):
     def decorator_computed(fn: T) -> T:
         fn.deep = deep
         fn.decorator = "computed"

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -30,7 +30,7 @@ def watch(
     return watcher
 
 
-def computed(_fn=None, *, deep=False):
+def computed(_fn=None, *, deep=True):
     def decorator_computed(fn: T) -> T:
         """
         Create a watcher for an expression.
@@ -188,9 +188,9 @@ class Watcher:
         Dep.stack.append(self)
         try:
             value = self.fn()
-        finally:
             if self.deep:
                 traverse(value)
+        finally:
             Dep.stack.pop()
             self.cleanup_deps()
         return value

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -9,7 +9,7 @@ def test_deps_copy():
     state = reactive({"foo": 5, "bar": 6})
     call_count = 0
 
-    @computed
+    @computed(deep=False)
     def prop():
         nonlocal call_count
         call_count += 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -77,11 +77,11 @@ def test_store_undo_redo_unchanged_watcher():
 
 def test_store_computed_deep():
     class DeepStore(Store):
-        @computed(deep=True)
+        @computed
         def deep_items(self):
             return self.state["items"]
 
-        @computed
+        @computed(deep=False)
         def shallow_items(self):
             return self.state["items"]
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -506,11 +506,11 @@ def test_watch_computed():
 def test_computed_deep():
     a = reactive({"items": []})
 
-    @computed
+    @computed(deep=False)
     def items():
         return a["items"]
 
-    @computed(deep=True)
+    @computed
     def items_deep():
         return a["items"]
 


### PR DESCRIPTION
Fixes #49.

In watcher.py I had to adjust the try/finally statement because when there is an exception, `value` will not be defined, so another exception will be thrown. And in the tests, we trigger such an exception (StateModifiedError).