### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 
 from .observables import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "observ"
-version = "0.7.2"
+version = "0.8.0"
 description = "Reactive state management for Python"
 authors = ["Korijn van Golen <korijn@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Included changes:

* Implement patch-based undo/redo in the store without the use of deepcopy (#50)
* Support Python 3.10 (#51)
* Make computed deep by default (#52)
* Avoid map function overhead in `to_raw` (#53)