### PR TITLE
Make sure proxy.target does not contain proxies

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 
 from .observables import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "observ"
-version = "0.7.2"
+version = "0.8.0"
 description = "Reactive state management for Python"
 authors = ["Korijn van Golen <korijn@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This should make the `to_raw` function much simpler.

The `to_raw` function does not do a deep check, so if values are assigned that have 'deep' proxied objects, then that's going to be a problem. So we might need a deep `to_raw` conversion function anyways. We could pass it as an argument for the `to_raw` function.