### PR TITLE
Tryout to generate patchdiff ops on-the-fly

### DIFF
--- a/observ/dep.py
+++ b/observ/dep.py
@@ -22,6 +22,29 @@ class Dep:
         if self.stack:
             self.stack[-1].add_dep(self)
 
-    def notify(self) -> None:
+    def notify(self, ops=None) -> None:
         for sub in sorted(self._subs, key=lambda s: s.id):
-            sub.update()
+            sub.update(ops)
+
+
+class Path:
+    stack = []
+
+    @classmethod
+    def put(cls, obj, component):
+        # Maybe try to start building the path from the
+        # object that is returned in the lambda? Is that
+        # even possible?
+        if (id(obj), component) in cls.stack:
+            # Should maybe clear from that index?
+            cls.stack.clear()
+        cls.stack.append((id(obj), component))
+        print("put", cls.stack)
+        # breakpoint()
+
+    @classmethod
+    def pop(cls):
+        if len(cls.stack):
+            cls.stack.pop()
+        # breakpoint()
+        print("pop", cls.stack)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ flake8 = "*"
 flake8-black = "*"
 flake8-import-order = "*"
 flake8-print = "*"
-pre-commit = { version = "*", python = ">=3.7"}
+pre-commit = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-timeout = "*"

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,166 @@
+from patchdiff import iapply
+
+from observ import reactive, watch
+from observ.dep import Path
+
+
+def test_shallow_list_ops():
+    a = reactive([])
+    b = []
+
+    last_ops = None
+
+    def callback(new, old, ops):
+        nonlocal last_ops
+        last_ops = ops
+
+    _ = watch(lambda: a, callback, sync=True, deep=True)
+
+    a.append(1)
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "add"
+    assert last_ops[0]["value"] == 1
+    assert last_ops[0]["path"].tokens == ["-"]
+    iapply(b, last_ops)
+    assert a == b
+
+    a.remove(1)
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "remove"
+    assert last_ops[0]["path"].tokens == [0]
+    iapply(b, last_ops)
+    assert a == b
+
+
+def test_shallow_dict_ops():
+    a = reactive({})
+    b = {}
+
+    last_ops = None
+
+    def callback(new, old, ops):
+        nonlocal last_ops
+        last_ops = ops
+
+    _ = watch(lambda: a, callback, sync=True, deep=True)
+
+    a[0] = 0
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "add"
+    assert last_ops[0]["value"] == 0
+    assert last_ops[0]["path"].tokens == [0]
+    iapply(b, last_ops)
+    assert a == b
+
+    a[0] = 1
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "replace"
+    assert last_ops[0]["value"] == 1
+    assert last_ops[0]["path"].tokens == [0]
+    iapply(b, last_ops)
+    assert a == b
+
+    del a[0]
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "remove"
+    assert last_ops[0]["path"].tokens == [0]
+    iapply(b, last_ops)
+    assert a == b
+
+    a.update(a=0)
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "add"
+    assert last_ops[0]["value"] == 0
+    assert last_ops[0]["path"].tokens == ["a"]
+    iapply(b, last_ops)
+    assert a == b
+
+
+def test_deep_dict_ops():
+    a = reactive({"a": {}})
+    c = reactive({"b": [1]})
+    b = {"a": {"b": 0}}
+
+    last_ops = None
+
+    def callback(new, old, ops):
+        nonlocal last_ops
+        last_ops = ops
+
+    _ = watch(lambda: a, callback, sync=True, deep=True)
+
+    a["a"]["b"] = 0
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "add"
+    assert last_ops[0]["value"] == 0
+    assert last_ops[0]["path"].tokens == ["a", "b"]
+    iapply(b, last_ops)
+    assert a == b
+
+    # TODO: how to figure out which scope we are???
+    assert a["a"]
+    assert c["b"] == [1]
+
+    a["a"]["b"] = 1
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "replace"
+    assert last_ops[0]["value"] == 1
+    assert last_ops[0]["path"].tokens == ["a", "b"]
+    iapply(b, last_ops)
+    assert a == b
+
+
+def test_deep_dict_combined_ops():
+    a = reactive({"a": {"b": {"c": {"d": [{"a": 0}]}}}})
+    b = {"a": {"b": {"c": {"d": [{"a": 0}]}}}}
+
+    last_ops = None
+    path = None
+
+    def callback(new, old, ops):
+        nonlocal last_ops
+        nonlocal path
+        last_ops = ops
+        path = [p for _, p in Path.stack.copy()]
+
+    _ = watch(lambda: a, callback, sync=True, deep=True)
+
+    a["a"]["b"]["c"]["d"][0]["a"] = 1
+    assert path == ["a", "b", "c", "d", 0]
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "replace"
+    assert last_ops[0]["value"] == 1
+    assert last_ops[0]["path"].tokens == ["a", "b", "c", "d", 0, "a"]
+    iapply(b, last_ops)
+    assert a == b
+
+
+# TODO: add test for watchers that watch a specific path within the reactive data
+
+
+def test_shallow_set_ops():
+    a = reactive(set())
+    b = set()
+
+    last_ops = None
+
+    def callback(new, old, ops):
+        nonlocal last_ops
+        last_ops = ops
+
+    _ = watch(lambda: a, callback, sync=True, deep=True)
+
+    a.add("a")
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "add"
+    assert last_ops[0]["path"].tokens == ["-"]
+    assert last_ops[0]["value"] == "a"
+    iapply(b, last_ops)
+    assert a == b
+
+    a.remove("a")
+    assert len(last_ops) == 1
+    assert last_ops[0]["op"] == "remove"
+    assert last_ops[0]["path"].tokens == ["a"]
+    iapply(b, last_ops)
+    assert a == b

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -137,3 +137,24 @@ def test_store_undo_redo_all_types():
     assert store.state["dict"] == {"a": "b", "b": "c"}
     store.undo()
     assert store.state["dict"] == {"a": "b"}
+
+
+def test_store_undo_extend():
+    class ListStore(Store):
+        @mutation
+        def add(self, items):
+            self.state["list"].extend(items)
+
+    store = ListStore({"list": []})
+
+    # This works in v0.8.1
+    store.add(["a", "b"])
+    assert store.state["list"] == ["a", "b"]
+    store.undo()
+    assert store.state["list"] == []
+
+    # This raises an IndexError in v0.8.1 on `store.undo()`
+    store.add(["a", "b", "c"])
+    assert store.state["list"] == ["a", "b", "c"]
+    store.undo()
+    assert store.state["list"] == []


### PR DESCRIPTION
I've taken a very naive and explorative approach to generating patchdiff ops. There are tons of problems with this, but I guess that that is exactly what I wanted to figure out: what would we want from the generated ops and how are we going to achieve that?

I started out with adding another argument `ops` to the callback function, so that you can receive the actual patchdiff ops next to the `new` and `old` value. Already the first problem with this is: within the watcher expression, there could be any type of expression, while we can only easily generate `ops` for the changes in the underlying reactive data structures. So the `ops` returned here might not map directly to the `old` and `new` values...

Then there is another problem: how do you keep track of the 'paths' for the `ops`?
