### PR TITLE
Improve exception inception

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -161,14 +161,14 @@ class Watcher:
             pass
 
         try:
-            self._run_callback(new, old)
-            self._number_of_callback_args = 2
+            self._run_callback()
+            self._number_of_callback_args = 0
             return
         except WrongNumberOfArgumentsError:
             pass
 
-        self._run_callback()
-        self._number_of_callback_args = 0
+        self._run_callback(new, old)
+        self._number_of_callback_args = 2
 
     def _run_callback(self, *args):
         """

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -156,13 +156,19 @@ class Watcher:
         try:
             self._run_callback(new)
             self._number_of_callback_args = 1
+            return
         except WrongNumberOfArgumentsError:
-            try:
-                self._run_callback(new, old)
-                self._number_of_callback_args = 2
-            except WrongNumberOfArgumentsError:
-                self._run_callback()
-                self._number_of_callback_args = 0
+            pass
+
+        try:
+            self._run_callback(new, old)
+            self._number_of_callback_args = 2
+            return
+        except WrongNumberOfArgumentsError:
+            pass
+
+        self._run_callback()
+        self._number_of_callback_args = 0
 
     def _run_callback(self, *args):
         """


### PR DESCRIPTION
When a WrongNumberOfArgumentsError is raised, it is like an inception of errors:

```
>>> from observ import reactive, watch
>>> a = reactive({})
>>> watcher = watch(lambda: a, lambda a, b, c: print(a, b, c), sync=True, deep=True)
>>> a["a"] = "a"
Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 177, in _run_callback
    self.callback(*args)
TypeError: <lambda>() missing 2 required positional arguments: 'b' and 'c'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 157, in run_callback
    self._run_callback(new)
  File "/Users/cg/Development/observ/observ/watcher.py", line 183, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: <lambda>() missing 2 required positional arguments: 'b' and 'c'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 177, in _run_callback
    self.callback(*args)
TypeError: <lambda>() missing 1 required positional argument: 'c'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 161, in run_callback
    self._run_callback(new, old)
  File "/Users/cg/Development/observ/observ/watcher.py", line 183, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: <lambda>() missing 1 required positional argument: 'c'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 177, in _run_callback
    self.callback(*args)
TypeError: <lambda>() missing 3 required positional arguments: 'a', 'b', and 'c'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/cg/Development/observ/observ/observables.py", line 301, in inner
    attrs["dep"].notify()
  File "/Users/cg/Development/observ/observ/dep.py", line 27, in notify
    sub.update()
  File "/Users/cg/Development/observ/observ/watcher.py", line 120, in update
    self.run()
  File "/Users/cg/Development/observ/observ/watcher.py", line 135, in run
    self.run_callback(self.value, old_value)
  File "/Users/cg/Development/observ/observ/watcher.py", line 164, in run_callback
    self._run_callback()
  File "/Users/cg/Development/observ/observ/watcher.py", line 183, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: <lambda>() missing 3 required positional arguments: 'a', 'b', and 'c'
```

This PR changes that to only raise one WrongNumberOfArgumentsError instead:
```
>>> from observ import reactive, watch
>>> a = reactive({})
>>> watcher = watch(lambda: a, lambda a, b, c: print(a, b, c), sync=True, deep=True)
>>> a["a"] = "a"
Traceback (most recent call last):
  File "/Users/cg/Development/observ/observ/watcher.py", line 183, in _run_callback
    self.callback(*args)
TypeError: <lambda>() missing 1 required positional argument: 'c'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/cg/Development/observ/observ/observables.py", line 301, in inner
    attrs["dep"].notify()
  File "/Users/cg/Development/observ/observ/dep.py", line 27, in notify
    sub.update()
  File "/Users/cg/Development/observ/observ/watcher.py", line 120, in update
    self.run()
  File "/Users/cg/Development/observ/observ/watcher.py", line 135, in run
    self.run_callback(self.value, old_value)
  File "/Users/cg/Development/observ/observ/watcher.py", line 170, in run_callback
    self._run_callback(new, old)
  File "/Users/cg/Development/observ/observ/watcher.py", line 189, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: <lambda>() missing 1 required positional argument: 'c'
```