### PR TITLE
Fix bug with many watchers

### DIFF
--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -71,7 +71,7 @@ class Scheduler:
             self.has.discard(watcher.id)
             watcher.run()
 
-            if self.detect_cycles:  # and watcher.id in self.has:
+            if self.detect_cycles:
                 self.circular[watcher.id] += 1
                 if self.circular[watcher.id] > 100:
                     raise RecursionError(

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -76,14 +76,16 @@ def traverse(obj, seen=None):
     # traversal) is an option but way more expensive than just using a list
     if seen is None:
         seen = []
-    seen.append(obj)
+    # since proxies may be garbage collected during traversal, it's not safe to use
+    # them for tracking, so we try to unwrap proxies where possible
+    obj_unwrapped = getattr(obj, "target", obj)
+    seen.append(obj_unwrapped)
     for v in val_iter:
         if (
             isinstance(
                 v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
             )
-            and v not in seen
-        ):
+        ) and getattr(v, "target", v) not in seen:
             traverse(v)
 
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -78,8 +78,7 @@ def traverse(obj, seen=None):
         seen = []
     # since proxies may be garbage collected during traversal, it's not safe to use
     # them for tracking, so we try to unwrap proxies where possible
-    obj_unwrapped = getattr(obj, "target", obj)
-    seen.append(obj_unwrapped)
+    seen.append(getattr(obj, "target", obj))
     for v in val_iter:
         if (
             isinstance(

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -72,7 +72,9 @@ def _traverse(obj, seen: set):
     else:
         return
     for v in val_iter:
-        if isinstance(v, Container) and id(v) not in seen:
+        if isinstance(
+            v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
+        ):
             _traverse(v, seen)
 
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -76,15 +76,13 @@ def traverse(obj, seen=None):
     # traversal) is an option but way more expensive than just using a list
     if seen is None:
         seen = []
-    # since proxies may be garbage collected during traversal, it's not safe to use
-    # them for tracking, so we try to unwrap proxies where possible
-    seen.append(getattr(obj, "target", obj))
+    seen.append(obj)
     for v in val_iter:
         if (
             isinstance(
                 v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
             )
-        ) and getattr(v, "target", v) not in seen:
+        ) and v not in seen:
             traverse(v, seen=seen)
 
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -85,7 +85,7 @@ def traverse(obj, seen=None):
                 v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
             )
         ) and getattr(v, "target", v) not in seen:
-            traverse(v)
+            traverse(v, seen=seen)
 
 
 # Every Watcher gets a unique ID which is used to

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -60,11 +60,6 @@ def traverse(obj):
     Recursively traverse the whole tree to make sure
     that all values have been 'get'
     """
-    _traverse(obj, set())
-
-
-def _traverse(obj, seen: set):
-    seen.add(id(obj))
     if isinstance(obj, (dict, DictProxyBase)):
         val_iter = iter(obj.values())
     elif isinstance(obj, (list, ListProxyBase, set, SetProxyBase, tuple)):
@@ -75,7 +70,7 @@ def _traverse(obj, seen: set):
         if isinstance(
             v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
         ):
-            _traverse(v, seen)
+            traverse(v)
 
 
 # Every Watcher gets a unique ID which is used to

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -55,20 +55,34 @@ def computed(_fn=None, *, deep=True):
     return decorator_computed(_fn)
 
 
-def traverse(obj):
+def traverse(obj, seen=None):
     """
     Recursively traverse the whole tree to make sure
     that all values have been 'get'
     """
+    # we are only interested in traversing a fixed set of types
+    # otherwise we can just exit
     if isinstance(obj, (dict, DictProxyBase)):
         val_iter = iter(obj.values())
     elif isinstance(obj, (list, ListProxyBase, set, SetProxyBase, tuple)):
         val_iter = iter(obj)
     else:
         return
+    # track which objects we have already seen to support(!) full traversal
+    # of datastructures with cycles
+    # NOTE: a set would provide faster containment checks
+    # but these objects are not hashable (except for tuple) because they are mutable
+    # converting everything to a hashable thing (because nothing is mutated during
+    # traversal) is an option but way more expensive than just using a list
+    if seen is None:
+        seen = []
+    seen.append(obj)
     for v in val_iter:
-        if isinstance(
-            v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
+        if (
+            isinstance(
+                v, (dict, DictProxyBase, list, ListProxyBase, set, SetProxyBase, tuple)
+            )
+            and v not in seen
         ):
             traverse(v)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -171,7 +171,6 @@ def test_queue_cycle_indirect(noop_request_flush):
         scheduler.flush()
 
 
-@pytest.mark.xfail
 def test_lots_of_watchers(noop_request_flush):
     """
     Test with a lot of watchers

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,7 +10,7 @@ def test_no_flush_handler():
     state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
-    def cb(old, new):
+    def cb(new, old):
         nonlocal calls
         calls += 1
 
@@ -27,7 +27,7 @@ def test_flush(noop_request_flush):
     state = reactive({"foo": 5, "bar": 6})
     calls = 0
 
-    def cb(old, new):
+    def cb(new, old):
         nonlocal calls
         calls += 1
 
@@ -57,7 +57,7 @@ def test_cycle_expression(noop_request_flush):
     def exp():
         return state["foo"]
 
-    def cb(old, new):
+    def cb(new, old):
         state["foo"] += 1
         nonlocal calls
         calls += 1
@@ -85,7 +85,7 @@ def test_cycle_callback(noop_request_flush):
     def exp():
         return state["foo"]
 
-    def cb(old, new):
+    def cb(new, old):
         nonlocal calls
         calls += 1
         state["foo"] += 1
@@ -111,12 +111,12 @@ def test_queue_growth(noop_request_flush):
     calls_1 = 0
     calls_2 = 0
 
-    def cb_1(old, new):
+    def cb_1(new, old):
         nonlocal calls_1
         calls_1 += 1
         state["bar"] += 1
 
-    def cb_2(old, new):
+    def cb_2(new, old):
         nonlocal calls_2
         calls_2 += 1
 
@@ -147,12 +147,12 @@ def test_queue_cycle_indirect(noop_request_flush):
     calls_1 = 0
     calls_2 = 0
 
-    def cb_1(old, new):
+    def cb_1(new, old):
         nonlocal calls_1
         calls_1 += 1
         state["bar"] += 1
 
-    def cb_2(old, new):
+    def cb_2(new, old):
         nonlocal calls_2
         state["foo"] += 1
         calls_2 += 1
@@ -169,3 +169,30 @@ def test_queue_cycle_indirect(noop_request_flush):
 
     with pytest.raises(RecursionError):
         scheduler.flush()
+
+
+@pytest.mark.xfail
+def test_lots_of_watchers(noop_request_flush):
+    """
+    Test with a lot of watchers
+    """
+    state = reactive({"items": [[["Item", "Value"], False], [["Foo", "Bar"], False]]})
+
+    calls = 0
+
+    def cb():
+        nonlocal calls
+        calls += 1
+
+    nr_of_watchers = 100
+    watchers = []
+    for _ in range(nr_of_watchers):
+        watchers.append(watch(lambda: state, cb, deep=True))
+
+    state["items"][1][1] = True
+
+    assert calls == 0
+
+    scheduler.flush()
+
+    assert calls == nr_of_watchers


### PR DESCRIPTION
Closes #70.

There is a bug in the traverse code that is triggered when using many watchers (on the same data?). It seems that the traverse code skips objects that have been 'seen' before, but apparently this does not seem to work how we thought it would work...

Instead, when we simply traverse everything, then all the watchers are properly queued and triggered.