### PR TITLE
Fix for deep watching icw dict.setdefault()

### DIFF
--- a/observ/observables.py
+++ b/observ/observables.py
@@ -296,6 +296,10 @@ def write_key_trap(method, obj_cls):
         is_new = key not in attrs["keydep"]
         old_value = getitem_fn(self.target, key) if not is_new else None
         retval = fn(self.target, *args, **kwargs)
+        if method == "setdefault" and not self.shallow:
+            # This method is only available when readonly is false
+            retval = reactive(retval)
+
         new_value = getitem_fn(self.target, key)
         if is_new:
             attrs["keydep"][key] = Dep()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -685,3 +685,29 @@ def test_watch_get_non_existing_list():
     a.append("foo")
 
     assert watcher.value is True
+
+
+def test_watch_setdefault_new_key():
+    a = reactive(dict())
+    cb = Mock()
+
+    watcher = watch(lambda: a, cb, sync=True, deep=True)  # noqa: F841
+
+    some_list = a.setdefault("foo", [])
+    assert cb.call_count == 1
+
+    some_list.append("bar")
+    assert cb.call_count == 2
+
+
+def test_watch_setdefault_existing_key():
+    a = reactive({"foo": []})
+    cb = Mock()
+
+    watcher = watch(lambda: a, cb, sync=True, deep=True)  # noqa: F841
+
+    some_list = a.setdefault("foo", [])
+    assert cb.call_count == 0
+
+    some_list.append("bar")
+    assert cb.call_count == 1


### PR DESCRIPTION
The read traps return proxies for their return values. This should also happen for `setdefault` as it also is kind of a reader.