### PR TITLE
Add strict argument to store for ignoring empty mutations on the store

### DIFF
--- a/observ/store.py
+++ b/observ/store.py
@@ -24,8 +24,11 @@ def mutation(fn: T) -> T:
             current = to_raw(self.state)
             fn(self, *args, **kwargs)
             ops, reverse_ops = patchdiff.diff(current, self.state)
-            self._past.append((ops, reverse_ops))
-            self._future.clear()
+            # If ops and reverse_ops are empty, that means
+            # that there are no actual changes to record
+            if ops or reverse_ops:
+                self._past.append((ops, reverse_ops))
+                self._future.clear()
         finally:
             self.state = readonly_state
 

--- a/observ/store.py
+++ b/observ/store.py
@@ -26,7 +26,7 @@ def mutation(fn: T) -> T:
             ops, reverse_ops = patchdiff.diff(current, self.state)
             # If ops and reverse_ops are empty, that means
             # that there are no actual changes to record
-            if ops or reverse_ops:
+            if self._strict or ops or reverse_ops:
                 self._past.append((ops, reverse_ops))
                 self._future.clear()
         finally:
@@ -51,10 +51,13 @@ class Store:
     Store that tracks mutations to state in order to enable undo/redo functionality
     """
 
-    def __init__(self, state: Collection):
+    def __init__(self, state: Collection, strict=True):
         """
         Creates a store with the given state as the initial state.
+        When `strict` is False, calling mutations that do not result
+        in an actual change will be ignored.
         """
+        self._strict = strict
         self._present = reactive(state)
         self._past = shallow_reactive([])
         self._future = shallow_reactive([])

--- a/observ/store.py
+++ b/observ/store.py
@@ -27,6 +27,11 @@ def mutation(fn: T) -> T:
             # If ops and reverse_ops are empty, that means
             # that there are no actual changes to record
             if self._strict or ops or reverse_ops:
+                if not ops and not reverse_ops:
+                    raise RuntimeError(
+                        "Calling mutation didn't result in any change to state"
+                    )
+
                 self._past.append((ops, reverse_ops))
                 self._future.clear()
         finally:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import pytest
+
 from observ import watch
 from observ.store import computed, mutation, Store
 
@@ -139,7 +141,7 @@ def test_store_undo_redo_all_types():
     assert store.state["dict"] == {"a": "b"}
 
 
-def test_store_empty_mutation():
+def test_store_empty_mutation_non_strict_store():
     class SimpleStore(Store):
         @mutation
         def update_count(self, count):
@@ -159,3 +161,21 @@ def test_store_empty_mutation():
     # that a change will actually be recorded
     store.update_count(2)
     assert store.can_undo
+
+
+def test_store_empty_mutation_strict_store():
+    class SimpleStore(Store):
+        @mutation
+        def update_count(self, count):
+            self.state["count"] = count
+
+    # Create a store with strict set to True
+    # (is the default value for `strict` argument)
+    store = SimpleStore({"count": 1})
+    assert store.state["count"] == 1
+    assert not store.can_undo
+
+    # Update with the same number. This should
+    # trigger a RuntimeError
+    with pytest.raises(RuntimeError):
+        store.update_count(1)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -145,7 +145,8 @@ def test_store_empty_mutation():
         def update_count(self, count):
             self.state["count"] = count
 
-    store = SimpleStore({"count": 1})
+    # Create a store with strict set to False
+    store = SimpleStore({"count": 1}, strict=False)
     assert store.state["count"] == 1
     assert not store.can_undo
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -137,3 +137,24 @@ def test_store_undo_redo_all_types():
     assert store.state["dict"] == {"a": "b", "b": "c"}
     store.undo()
     assert store.state["dict"] == {"a": "b"}
+
+
+def test_store_empty_mutation():
+    class SimpleStore(Store):
+        @mutation
+        def update_count(self, count):
+            self.state["count"] = count
+
+    store = SimpleStore({"count": 1})
+    assert store.state["count"] == 1
+    assert not store.can_undo
+
+    # Update with the same number. This should
+    # result in no change being recorded
+    store.update_count(1)
+    assert not store.can_undo
+
+    # Check that if we do supply another number
+    # that a change will actually be recorded
+    store.update_count(2)
+    assert store.can_undo


### PR DESCRIPTION
Currently, when a mutation on the store is called that doesn't actually change anything, the undo stack is still updated.
This PR adds a `strict` argument to the Store constructor to control its behaviour:

* `strict = True` (default) will raise a `RuntimeError` when no change is made within a mutation
* `strict = False` will ignore empty mutations