### PR TITLE
Store weak references to bound methods

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -297,7 +297,9 @@ def weak(obj: Any, method: Callable):
 
         return wrapped
     else:
-        raise NotImplementedError
+        raise WrongNumberOfArgumentsError(
+            "Please use 1, 2 or 3 arguments for callbacks"
+        )
 
 
 def is_bound_method(fn: Callable):

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -260,16 +260,12 @@ class Watcher:
         return f"{self.fn.__module__}.{self.fn.__qualname__}"
 
 
-def weak(obj, method):
+def weak(obj: Any, method: Callable):
     """
-    Prevent the strong capture of the given object by using a weakref.ref instead.
-    Assumes the first argument to the method to be the argument for which a weak ref
-    is made.
-
-    The wrapped method will only be called, if the weak ref object is actually still
-    alive.
-
-    This will ensure that the method does not capture a strong reference to the object.
+    Returns a wrapper for the given method that will only call the method if the
+    given object is not garbage collected yet. It does so by using a weakref.ref
+    and checking its value before calling the actual method when the wrapper is
+    called.
     """
     weak_obj = ref(obj)
 
@@ -304,7 +300,7 @@ def weak(obj, method):
         raise NotImplementedError
 
 
-def is_bound_method(fn):
+def is_bound_method(fn: Callable):
     """
     Returns whether the given function is a bound method.
     """

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -107,65 +107,6 @@ class WrongNumberOfArgumentsError(TypeError):
     pass
 
 
-def weak(obj):
-    """
-    Prevent the strong capture of the given object
-    by using a weakref.ref instead.
-    This decorator assumes the first argument to the method
-    to be argument for which a weak ref is made.
-
-    The wrapper method will actually have it's first argument
-    popped, with the assumption that it will coincide with the
-    weak ref object.
-
-    The wrapped method will then be called, only if the
-    weak ref object is actually still alive.
-
-    Example usage:
-
-        @weak(self)
-        def callback(self):
-            print(self)
-
-    This will ensure the callback function does not capture
-    a strong reference to self.
-    """
-    weak_obj = ref(obj)
-
-    def wrapper(method):
-        sig = inspect.signature(method)
-        nr_arguments = len(sig.parameters)
-
-        if nr_arguments == 1:
-
-            @wraps(method)
-            def wrapped():
-                if this := weak_obj():
-                    return method(this)
-
-            return wrapped
-        elif nr_arguments == 2:
-
-            @wraps(method)
-            def wrapped(new):
-                if this := weak_obj():
-                    return method(this, new)
-
-            return wrapped
-        elif nr_arguments == 3:
-
-            @wraps(method)
-            def wrapped(new, old):
-                if this := weak_obj():
-                    return method(this, new, old)
-
-            return wrapped
-        else:
-            raise NotImplementedError
-
-    return wrapper
-
-
 class Watcher:
     def __init__(
         self,
@@ -183,8 +124,8 @@ class Watcher:
         """
         self.id = next(_ids)
         if callable(fn):
-            if hasattr(fn, "__self__") and hasattr(fn, "__func__"):
-                self.fn = weak(fn.__self__)(fn.__func__)
+            if is_bound_method(fn):
+                self.fn = weak(fn.__self__, fn.__func__)
             else:
                 self.fn = fn
         else:
@@ -196,8 +137,8 @@ class Watcher:
         self._deps, self._new_deps = WeakSet(), WeakSet()
 
         self.sync = sync
-        if hasattr(callback, "__func__") and hasattr(callback, "__self__"):
-            self.callback = weak(callback.__self__)(callback.__func__)
+        if is_bound_method(callback):
+            self.callback = weak(callback.__self__, callback.__func__)
         else:
             self.callback = callback
         self.deep = bool(deep)
@@ -317,3 +258,54 @@ class Watcher:
     @property
     def fn_fqn(self) -> str:
         return f"{self.fn.__module__}.{self.fn.__qualname__}"
+
+
+def weak(obj, method):
+    """
+    Prevent the strong capture of the given object by using a weakref.ref instead.
+    Assumes the first argument to the method to be the argument for which a weak ref
+    is made.
+
+    The wrapped method will only be called, if the weak ref object is actually still
+    alive.
+
+    This will ensure that the method does not capture a strong reference to the object.
+    """
+    weak_obj = ref(obj)
+
+    sig = inspect.signature(method)
+    nr_arguments = len(sig.parameters)
+
+    if nr_arguments == 1:
+
+        @wraps(method)
+        def wrapped():
+            if this := weak_obj():
+                return method(this)
+
+        return wrapped
+    elif nr_arguments == 2:
+
+        @wraps(method)
+        def wrapped(new):
+            if this := weak_obj():
+                return method(this, new)
+
+        return wrapped
+    elif nr_arguments == 3:
+
+        @wraps(method)
+        def wrapped(new, old):
+            if this := weak_obj():
+                return method(this, new, old)
+
+        return wrapped
+    else:
+        raise NotImplementedError
+
+
+def is_bound_method(fn):
+    """
+    Returns whether the given function is a bound method.
+    """
+    return hasattr(fn, "__self__") and hasattr(fn, "__func__")

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -57,14 +57,6 @@ def test_no_strong_reference_to_callback():
 
 
 def test_no_strong_reference_to_fn():
-    count = 0
-
-    def cb():
-        nonlocal count
-        count += 1
-
-    state = reactive({"count": 0})
-
     class Counter:
         def __init__(self, state):
             self.state = state
@@ -72,6 +64,13 @@ def test_no_strong_reference_to_fn():
         def count(self):
             return self.state["count"]
 
+    count = 0
+
+    def cb():
+        nonlocal count
+        count += 1
+
+    state = reactive({"count": 0})
     counter = Counter(state)
 
     counter.watcher = watch(

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,126 @@
+from PySide6 import QtWidgets
+
+from observ import reactive, watch
+
+
+def test_no_strong_reference_to_callback():
+    class Counter:
+        count_a = 0
+        count_b = 0
+        count_c = 0
+
+        def count(self):
+            type(self).count_a += 1
+
+        def count_new(self, new):
+            type(self).count_b = new
+
+        def count_new_old(self, new, old):
+            type(self).count_c += new - (old or 0)
+
+    state = reactive({"count": 0})
+
+    counter = Counter()
+
+    counter.watcher_a = watch(
+        lambda: state["count"],
+        counter.count,
+        deep=True,
+        sync=True,
+    )
+    counter.watcher_b = watch(
+        lambda: state["count"],
+        counter.count_new,
+        deep=True,
+        sync=True,
+    )
+    counter.watcher_c = watch(
+        lambda: state["count"],
+        counter.count_new_old,
+        deep=True,
+        sync=True,
+    )
+
+    state["count"] += 1
+
+    assert Counter.count_a == 1
+    assert Counter.count_b == 1
+    assert Counter.count_c == 1
+
+    del counter
+
+    state["count"] += 1
+
+    assert Counter.count_a == 1
+    assert Counter.count_b == 1
+    assert Counter.count_c == 1
+
+
+def test_no_strong_reference_to_fn():
+    count = 0
+
+    def cb():
+        nonlocal count
+        count += 1
+
+    state = reactive({"count": 0})
+
+    class Counter:
+        def __init__(self, state):
+            self.state = state
+
+        def count(self):
+            return self.state["count"]
+
+    counter = Counter(state)
+
+    counter.watcher = watch(
+        counter.count,
+        cb,
+        deep=True,
+        sync=True,
+    )
+
+    state["count"] += 1
+
+    assert count == 1
+
+    del counter
+
+    state["count"] += 1
+
+    assert count == 1
+
+
+def test_qt_integration(qapp):
+    class Widget(QtWidgets.QWidget):
+        count = 0
+
+        def __init__(self, state):
+            super().__init__()
+            self.state = state
+            self.label = QtWidgets.QLabel()
+
+            self.watcher = watch(
+                self.count_display,
+                self.label.setText,
+                deep=True,
+                sync=True,
+            )
+
+        def count_display(self):
+            return str(self.state["count"])
+
+        def __del__(self):
+            Widget.count += 1
+
+    state = reactive({"count": 0})
+    widget = Widget(state)
+
+    state["count"] += 1
+
+    assert widget.label.text() == "1"
+
+    del widget
+
+    assert Widget.count == 1


### PR DESCRIPTION
This solves a problem where functions and callbacks store strong references to `self` which can prevent an object (and associated watchers) from being garbage collected.

- [x] convert weak decorator into a function that takes object and method as args