### PR TITLE
Add async/await support for watch expressions and callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: poetry install
       - name: Lint
         run: poetry run flake8
-  
+
   test:
     name: Test on ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -57,9 +57,11 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Test
-        run: poetry run pytest --cov=observ --cov-report=term-missing
+        run: poetry run pytest -v --cov=observ --cov-report=term-missing tests
         env:
           QT_QPA_PLATFORM: offscreen
+      - name: Bench
+        run: poetry run pytest -v bench
 
   build:
     name: Build and test wheel

--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.13.1"
 
 
+from .init import init, loop_factory
 from .proxy import (
     reactive,
     readonly,
@@ -10,4 +11,4 @@ from .proxy import (
     to_raw,
 )
 from .scheduler import scheduler
-from .watcher import computed, watch, watch_effect
+from .watcher import computed, watch, watch_effect, Watcher

--- a/observ/init.py
+++ b/observ/init.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from .scheduler import scheduler
+
+
+def init(mode="asyncio"):
+    if mode == "qt":
+        scheduler.register_qt()
+
+    if mode == "asyncio":
+        scheduler.register_asyncio()
+
+
+def loop_factory():
+    loop = asyncio.new_event_loop()
+    if hasattr(asyncio, "eager_task_factory"):
+        loop.set_task_factory(asyncio.eager_task_factory)
+    return loop

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -79,7 +79,7 @@ class Scheduler:
             warnings.warn(
                 "QtAsyncio module available: please consider using `register_asyncio` "
                 "and call the following code:\n"
-                f"    from {qt} import QtAsyncio\n"
+                f"    from {qt} import QtAsyncio\n"  # noqa: E272
                 "    asyncio.set_event_loop_policy(QtAsyncio.QAsyncioEventLoopPolicy())"
                 ""
             )

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -2,6 +2,7 @@
 The scheduler queues up and deduplicates re-evaluation of lazy Watchers
 and should be integrated in the event loop of your choosing.
 """
+import asyncio
 from bisect import bisect
 from collections import defaultdict
 import importlib
@@ -44,17 +45,15 @@ class Scheduler:
         """
         self.request_flush = callback
 
+    def request_flush_asyncio(self):
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+        loop.call_soon(self.flush)
+
     def register_asyncio(self):
         """
         Utility function for integration with asyncio
         """
-        import asyncio
-
-        def request_flush():
-            loop = asyncio.get_event_loop_policy().get_event_loop()
-            loop.call_soon(scheduler.flush)
-
-        scheduler.register_request_flush(request_flush)
+        self.register_request_flush(self.request_flush_asyncio)
 
     def register_qt(self):
         """

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -25,7 +25,6 @@ Watchable = Union[
     Callable[[], T],
     Callable[[], Awaitable[T]],
     T,
-    list[T],
 ]
 WatchCallback = Union[Callable[[], Any], Callable[[T], Any], Callable[[T, T], Any]]
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -236,7 +236,7 @@ class Watcher:
 
         if self.callback_async and maybe_coro:
             loop = asyncio.get_event_loop_policy().get_event_loop()
-            if self.sync and not loop.is_running():
+            if not loop.is_running():
                 loop.run_until_complete(maybe_coro)
             else:
                 loop.create_task(maybe_coro)
@@ -267,7 +267,7 @@ class Watcher:
             value_or_coro = self.fn()
             if self.fn_async and value_or_coro:
                 loop = asyncio.get_event_loop_policy().get_event_loop()
-                if self.sync and not loop.is_running():
+                if not loop.is_running():
                     loop.run_until_complete(value_or_coro)
                 else:
                     loop.create_task(value_or_coro)

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -154,18 +154,6 @@ class Watcher:
             else:
                 self.fn = fn
             self.fn_async = inspect.iscoroutinefunction(fn)
-            if self.fn_async:
-                loop = asyncio.get_event_loop_policy().get_event_loop()
-                try:
-                    if loop.get_task_factory() is not asyncio.eager_task_factory:
-                        raise RuntimeError(
-                            "async watch expressions are only supported"
-                            "when asyncio.eager_task_factory is configured"
-                        )
-                except AttributeError:
-                    raise RuntimeError(
-                        "async watch expressions are only supported on python>=3.12"
-                    )
         else:
             self.fn = lambda: fn
             self.fn_async = False

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -279,8 +279,8 @@ class Watcher:
             value_or_coro = self.fn()
             if self.fn_async and value_or_coro:
                 loop = asyncio.get_event_loop_policy().get_event_loop()
-                # with eager_task_factory the coroutine will run synchronously
-                # until the first `await` statement
+                if not loop.is_running():
+                    raise RuntimeError("Not gonna work")
                 loop.create_task(value_or_coro)
                 return
             if self.deep:

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -269,10 +269,10 @@ class Watcher(Generic[T]):
             if self.fn_async and value_or_coro:
                 loop = asyncio.get_event_loop_policy().get_event_loop()
                 if not loop.is_running():
-                    loop.run_until_complete(value_or_coro)
+                    value_or_coro = loop.run_until_complete(value_or_coro)
                 else:
                     loop.create_task(value_or_coro)
-                return
+                    return
             if self.deep:
                 traverse(value_or_coro)
         finally:

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -267,8 +267,6 @@ class Watcher:
             value_or_coro = self.fn()
             if self.fn_async and value_or_coro:
                 loop = asyncio.get_event_loop_policy().get_event_loop()
-                if not loop.is_running():
-                    raise RuntimeError("Not gonna work")
                 loop.create_task(value_or_coro)
                 return
             if self.deep:

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -262,16 +262,15 @@ class Watcher:
                 del frames
 
     def get(self) -> Any:
-        if self.fn_async:
-            loop = asyncio.get_event_loop_policy().get_event_loop()
-            if not loop.is_running():
-                raise RuntimeError("event loop must be running for dependency tracking")
-
         Dep.stack.append(self)
         try:
             value_or_coro = self.fn()
             if self.fn_async and value_or_coro:
-                loop.create_task(value_or_coro)
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+                if self.sync and not loop.is_running():
+                    loop.run_until_complete(value_or_coro)
+                else:
+                    loop.create_task(value_or_coro)
                 return
             if self.deep:
                 traverse(value_or_coro)

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -154,18 +154,18 @@ class Watcher:
             else:
                 self.fn = fn
             self.fn_async = inspect.iscoroutinefunction(fn)
-            # if self.fn_async:
-            #     loop = asyncio.get_event_loop_policy().get_event_loop()
-            #     try:
-            #         if loop.get_task_factory() is not asyncio.eager_task_factory:
-            #             raise RuntimeError(
-            #                 "async watch expressions are only supported"
-            #                 "when asyncio.eager_task_factory is configured"
-            #             )
-            #     except AttributeError:
-            #         raise RuntimeError(
-            #             "async watch expressions are only supported on python>=3.12"
-            #         )
+            if self.fn_async:
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+                try:
+                    if loop.get_task_factory() is not asyncio.eager_task_factory:
+                        raise RuntimeError(
+                            "async watch expressions are only supported"
+                            "when asyncio.eager_task_factory is configured"
+                        )
+                except AttributeError:
+                    raise RuntimeError(
+                        "async watch expressions are only supported on python>=3.12"
+                    )
         else:
             self.fn = lambda: fn
             self.fn_async = False

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -154,18 +154,18 @@ class Watcher:
             else:
                 self.fn = fn
             self.fn_async = inspect.iscoroutinefunction(fn)
-            if self.fn_async:
-                loop = asyncio.get_event_loop_policy().get_event_loop()
-                try:
-                    if loop.get_task_factory() is not asyncio.eager_task_factory:
-                        raise RuntimeError(
-                            "async watch expressions are only supported"
-                            "when asyncio.eager_task_factory is configured"
-                        )
-                except AttributeError:
-                    raise RuntimeError(
-                        "async watch expressions are only supported on python>=3.12"
-                    )
+            # if self.fn_async:
+            #     loop = asyncio.get_event_loop_policy().get_event_loop()
+            #     try:
+            #         if loop.get_task_factory() is not asyncio.eager_task_factory:
+            #             raise RuntimeError(
+            #                 "async watch expressions are only supported"
+            #                 "when asyncio.eager_task_factory is configured"
+            #             )
+            #     except AttributeError:
+            #         raise RuntimeError(
+            #             "async watch expressions are only supported on python>=3.12"
+            #         )
         else:
             self.fn = lambda: fn
             self.fn_async = False

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -6,7 +6,7 @@ a change is detected.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Container
+from collections.abc import Awaitable, Container
 from functools import partial, wraps
 import inspect
 from itertools import count
@@ -21,7 +21,12 @@ from .set_proxy import SetProxyBase
 
 
 T = TypeVar("T")
-Watchable = Union[Callable[[], T], T]
+Watchable = Union[
+    Callable[[], T],
+    Callable[[], Awaitable[T]],
+    T,
+    list[T],
+]
 WatchCallback = Union[Callable[[], Any], Callable[[T], Any], Callable[[T, T], Any]]
 
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -311,30 +311,55 @@ def weak(obj: Any, method: Callable):
     weak_obj = ref(obj)
 
     sig = inspect.signature(method)
+    iscoro = inspect.iscoroutinefunction(method)
     nr_arguments = len(sig.parameters)
 
     if nr_arguments == 1:
+        if iscoro:
 
-        @wraps(method)
-        def wrapped():
-            if this := weak_obj():
-                return method(this)
+            @wraps(method)
+            async def wrapped():
+                if this := weak_obj():
+                    return await method(this)
+
+        else:
+
+            @wraps(method)
+            def wrapped():
+                if this := weak_obj():
+                    return method(this)
 
         return wrapped
     elif nr_arguments == 2:
+        if iscoro:
 
-        @wraps(method)
-        def wrapped(new):
-            if this := weak_obj():
-                return method(this, new)
+            @wraps(method)
+            async def wrapped(new):
+                if this := weak_obj():
+                    return await method(this, new)
+
+        else:
+
+            @wraps(method)
+            def wrapped(new):
+                if this := weak_obj():
+                    return method(this, new)
 
         return wrapped
     elif nr_arguments == 3:
+        if iscoro:
 
-        @wraps(method)
-        def wrapped(new, old):
-            if this := weak_obj():
-                return method(this, new, old)
+            @wraps(method)
+            async def wrapped(new, old):
+                if this := weak_obj():
+                    return await method(this, new, old)
+
+        else:
+
+            @wraps(method)
+            def wrapped(new, old):
+                if this := weak_obj():
+                    return method(this, new, old)
 
         return wrapped
     else:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,0 +1,81 @@
+import asyncio
+import sys
+
+import pytest
+
+from observ import reactive, watch
+
+
+def test_asyncio_watch_callback():
+    a = reactive([1, 2])
+    called = 0
+
+    async def _callback():
+        nonlocal called
+        await asyncio.sleep(0)
+        called += 1
+
+    watcher = watch(lambda: len(a), _callback, sync=True)
+    assert not watcher.dirty
+    assert called == 0
+
+    a.append(3)
+    assert called == 1
+    assert len(a) == 3
+
+
+@pytest.fixture
+def asyncio_eager():
+    # only python>=3.12
+    if not getattr(asyncio, "eager_task_factory", None):
+        yield
+        return
+
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    loop.set_task_factory(asyncio.eager_task_factory)
+    try:
+        yield
+    finally:
+        loop.set_task_factory()
+
+
+def test_asyncio_watch_expression_not_supported():
+    a = reactive([1, 2])
+
+    async def _expr():
+        len_a = len(a)
+        await asyncio.sleep(0)
+        return len_a
+
+    # should raise runtimeerror
+    # either because python<3.12 or because
+    # task factory is not eager
+    with pytest.raises(RuntimeError):
+        watcher = watch(_expr, sync=True)  # noqa: F841
+
+
+def test_asyncio_watch_expression(asyncio_eager):
+    a = reactive([1, 2])
+    called = 0
+
+    async def _expr():
+        len_a = len(a)
+        await asyncio.sleep(0)
+        return len_a
+
+    def _callback():
+        nonlocal called
+        called += 1
+
+    if sys.version_info < (3, 12, 0):
+        with pytest.raises(RuntimeError):
+            watcher = watch(_expr, _callback, sync=True)
+        return
+
+    watcher = watch(_expr, _callback, sync=True)
+    assert not watcher.dirty
+    assert called == 0
+
+    a.append(3)
+    assert called == 1
+    assert len(a) == 3

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -289,14 +289,35 @@ def test_asyncio_watcher_multi(
         a.append(3)
 
     # ASSERTS pt II
-    if expr_async:
-        assert (called, completed) == (0, 0)
-    elif create_loop is create_plain_loop and callback_async and write_async:
+    if (
+        create_loop is create_plain_loop
+        and not expr_async
+        and callback_async
+        and write_async
+    ):
         assert (called, completed) == (1, 0)
+    elif (
+        create_loop is create_plain_loop
+        and expr_async
+        and callback_async
+        and not create_async
+        and write_async
+    ):
+        assert (called, completed) == (1, 0)
+    elif create_loop is create_plain_loop and expr_async and create_async:
+        assert (called, completed) == (0, 0)
+    elif (
+        create_loop is create_eager_loop and expr_async and create_async and write_async
+    ):
+        assert (called, completed) == (0, 0)
     else:
         assert (called, completed) == (1, 1)
     flush(loop)
-    if expr_async:
+    if create_loop is create_plain_loop and expr_async and create_async:
+        assert (called, completed) == (0, 0)
+    elif (
+        create_loop is create_eager_loop and expr_async and create_async and write_async
+    ):
         assert (called, completed) == (0, 0)
     else:
         assert (called, completed) == (1, 1)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -160,13 +160,19 @@ def test_asyncio_watch_effect_method(eager_loop):
 
 
 def test_asyncio_watch_effect_from_sync(eager_loop):
+    a = reactive([1, 2])
+    called = 0
+
     async def _expr():
-        pass
+        nonlocal called
+        len_a = len(a)  # noqa: F841
+        await asyncio.sleep(0)
+        called += 1
 
-    with pytest.raises(RuntimeError):
-        watch_effect(_expr, sync=True)
-
-    flush(eager_loop)
+    watcher = watch_effect(_expr, sync=True)  # noqa: F841
+    assert called == 1
+    a.append(3)
+    assert called == 2
 
 
 def test_asyncio_watcher_sync_callback_from_async(eager_loop):

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -32,11 +32,12 @@ def asyncio_eager():
         return
 
     loop = asyncio.get_event_loop_policy().get_event_loop()
+    old_factory = loop.get_task_factory()
     loop.set_task_factory(asyncio.eager_task_factory)
     try:
         yield
     finally:
-        loop.set_task_factory()
+        loop.set_task_factory(old_factory)
 
 
 def test_asyncio_watch_expression_not_supported():

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -7,13 +7,13 @@ from observ import reactive, watch, watch_effect
 
 
 @pytest.fixture
-def ensure_loop():
+def plain_loop():
     loop = asyncio.new_event_loop()
     asyncio.get_event_loop_policy().set_event_loop(loop)
     return loop
 
 
-def test_asyncio_watch_callback(ensure_loop):
+def test_asyncio_watch_callback(plain_loop):
     a = reactive([1, 2])
     called = 0
 
@@ -31,7 +31,7 @@ def test_asyncio_watch_callback(ensure_loop):
     assert len(a) == 3
 
 
-def test_asyncio_watch_expression_not_supported(ensure_loop):
+def test_asyncio_watch_expression_not_supported(plain_loop):
     a = reactive([1, 2])
 
     async def _expr():
@@ -47,22 +47,21 @@ def test_asyncio_watch_expression_not_supported(ensure_loop):
 
 
 @pytest.fixture
-def eager_loop(ensure_loop):
+def eager_loop(plain_loop):
     # only python>=3.12
     if not getattr(asyncio, "eager_task_factory", None):
         yield
         return
 
-    loop = ensure_loop
-    old_factory = loop.get_task_factory()
-    loop.set_task_factory(asyncio.eager_task_factory)
+    old_factory = plain_loop.get_task_factory()
+    plain_loop.set_task_factory(asyncio.eager_task_factory)
     try:
-        yield loop
+        yield plain_loop
     finally:
-        loop.set_task_factory(old_factory)
+        plain_loop.set_task_factory(old_factory)
 
 
-def test_asyncio_watch_effect(eager_loop):
+def test_asyncio_watch_effect_eager_loop(eager_loop):
     a = reactive([1, 2])
     called = 0
 
@@ -90,3 +89,27 @@ def test_asyncio_watch_effect(eager_loop):
 
     assert called == 2
     assert len(a) == 3
+
+
+def test_asyncio_watch_effect_plain_loop(plain_loop):
+    a = reactive([1, 2])
+    called = 0
+
+    async def _expr():
+        nonlocal called
+        len_a = len(a)  # noqa: F841
+        await asyncio.sleep(0)
+        called += 1
+
+    if sys.version_info < (3, 12, 0):
+        with pytest.raises(RuntimeError):
+            watcher = watch_effect(_expr, sync=True)
+        return
+
+    async def _coroutine():
+        return watch_effect(_expr, sync=True)
+
+    watcher = plain_loop.run_until_complete(_coroutine())  # noqa: F841
+
+    with pytest.xfail("doesn't work without eager loop"):
+        assert called == 1

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -3,10 +3,17 @@ import sys
 
 import pytest
 
-from observ import reactive, watch
+from observ import reactive, watch, watch_effect
 
 
-def test_asyncio_watch_callback():
+@pytest.fixture
+def ensure_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.get_event_loop_policy().set_event_loop(loop)
+    return loop
+
+
+def test_asyncio_watch_callback(ensure_loop):
     a = reactive([1, 2])
     called = 0
 
@@ -24,23 +31,7 @@ def test_asyncio_watch_callback():
     assert len(a) == 3
 
 
-@pytest.fixture
-def asyncio_eager():
-    # only python>=3.12
-    if not getattr(asyncio, "eager_task_factory", None):
-        yield
-        return
-
-    loop = asyncio.get_event_loop_policy().get_event_loop()
-    old_factory = loop.get_task_factory()
-    loop.set_task_factory(asyncio.eager_task_factory)
-    try:
-        yield
-    finally:
-        loop.set_task_factory(old_factory)
-
-
-def test_asyncio_watch_expression_not_supported():
+def test_asyncio_watch_expression_not_supported(ensure_loop):
     a = reactive([1, 2])
 
     async def _expr():
@@ -55,28 +46,47 @@ def test_asyncio_watch_expression_not_supported():
         watcher = watch(_expr, sync=True)  # noqa: F841
 
 
-def test_asyncio_watch_expression(asyncio_eager):
+@pytest.fixture
+def eager_loop(ensure_loop):
+    # only python>=3.12
+    if not getattr(asyncio, "eager_task_factory", None):
+        yield
+        return
+
+    loop = ensure_loop
+    old_factory = loop.get_task_factory()
+    loop.set_task_factory(asyncio.eager_task_factory)
+    try:
+        yield loop
+    finally:
+        loop.set_task_factory(old_factory)
+
+
+def test_asyncio_watch_effect(eager_loop):
     a = reactive([1, 2])
     called = 0
 
     async def _expr():
-        len_a = len(a)
-        await asyncio.sleep(0)
-        return len_a
-
-    def _callback():
         nonlocal called
+        len_a = len(a)  # noqa: F841
+        await asyncio.sleep(0)
         called += 1
 
     if sys.version_info < (3, 12, 0):
         with pytest.raises(RuntimeError):
-            watcher = watch(_expr, _callback, sync=True)
+            watcher = watch_effect(_expr, sync=True)
         return
 
-    watcher = watch(_expr, _callback, sync=True)
-    assert not watcher.dirty
-    assert called == 0
+    async def _coroutine():
+        return watch_effect(_expr, sync=True)
 
-    a.append(3)
+    watcher = eager_loop.run_until_complete(_coroutine())  # noqa: F841
     assert called == 1
+
+    async def _coroutine():
+        a.append(3)
+
+    eager_loop.run_until_complete(_coroutine())
+
+    assert called == 2
     assert len(a) == 3

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,11 @@ def test_loop_factory():
         else:
             return asyncio.get_running_loop()
 
-    loop = asyncio.run(_coroutine(), loop_factory=loop_factory)
+    if sys.version_info >= (3, 12):
+        actual_loop = asyncio.run(_coroutine(), loop_factory=loop_factory)
+    else:
+        loop = loop_factory()
+        actual_loop = loop.run_until_complete(_coroutine())
+
     if hasattr(asyncio, "eager_task_factory"):
-        assert loop.get_task_factory() is asyncio.eager_task_factory
+        assert actual_loop.get_task_factory() is asyncio.eager_task_factory

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,29 @@
+import asyncio
+import sys
+
+from observ import init, loop_factory, scheduler
+
+
+def flush(loop):
+    while pending := asyncio.all_tasks(loop):
+        loop.run_until_complete(asyncio.gather(*pending))
+
+
+def test_init_asyncio():
+    try:
+        init(mode="asyncio")
+        assert scheduler.request_flush == scheduler.request_flush_asyncio
+    finally:
+        scheduler.register_request_flush(scheduler.request_flush_raise)
+
+
+def test_loop_factory():
+    async def _coroutine():
+        if sys.version_info < (3, 10):
+            return asyncio.get_event_loop()
+        else:
+            return asyncio.get_running_loop()
+
+    loop = asyncio.run(_coroutine(), loop_factory=loop_factory)
+    if hasattr(asyncio, "eager_task_factory"):
+        assert loop.get_task_factory() is asyncio.eager_task_factory


### PR DESCRIPTION
Closes #102
Closes #115 

* `async def` callbacks
* `async def` watch expressions (most notably for `watch_effect`)

True async (meaning `sync=False`) watch expressions (not callbacks) are only supported starting with python 3.12 with [`asyncio.eager_task_factory`](https://docs.python.org/3/library/asyncio-task.html?highlight=eager_task_factory#asyncio.eager_task_factory)