### PR TITLE
Add global Watcher lifecycle hooks

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -129,8 +129,8 @@ class Watcher:
         "_number_of_callback_args",
         "__weakref__",
     ]
-    on_created = None
-    on_destroyed = None
+    on_created: Optional[Callable[[Watcher], None]] = None
+    on_destroyed: Optional[Callable[[Watcher], None]] = None
 
     def __init__(
         self,

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -129,6 +129,8 @@ class Watcher:
         "_number_of_callback_args",
         "__weakref__",
     ]
+    on_created = None
+    on_destroyed = None
 
     def __init__(
         self,
@@ -140,7 +142,7 @@ class Watcher:
     ) -> None:
         """
         sync: Ignore the scheduler
-        lazy: Only reevalutate when value is requested
+        lazy: Only reevaluate when value is requested
         deep: Deep watch the watched value
         callback: Method to call when value has changed
         """
@@ -169,6 +171,13 @@ class Watcher:
         self.dirty = self.lazy
         self.value = None if self.lazy else self.get()
         self._number_of_callback_args = None
+
+        if Watcher.on_created:
+            Watcher.on_created(self)
+
+    def __del__(self):
+        if Watcher.on_destroyed:
+            Watcher.on_destroyed(self)
 
     def update(self) -> None:
         if self.lazy:

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -130,8 +130,8 @@ class Watcher(Generic[T]):
         "_number_of_callback_args",
         "__weakref__",
     )
-    on_created: Optional[Callable[[Watcher], None]] = None
-    on_destroyed: Optional[Callable[[Watcher], None]] = None
+    on_created: Optional[Callable[[Watcher[T]], None]] = None
+    on_destroyed: Optional[Callable[[Watcher[T]], None]] = None
 
     def __init__(
         self,

--- a/tests/test_watcher_hooks.py
+++ b/tests/test_watcher_hooks.py
@@ -25,6 +25,7 @@ def test_watcher_hooks():
             called += 1
 
         watch(lambda: len(a), _callback, sync=True)
+        assert len(watchers) == 1
         assert called == 0
         a.append(3)
         assert called == 1

--- a/tests/test_watcher_hooks.py
+++ b/tests/test_watcher_hooks.py
@@ -1,0 +1,35 @@
+from observ import reactive, watch
+from observ.watcher import Watcher
+
+
+def test_watcher_hooks():
+    # demonstrate that watchers can be kept alive in a global registry
+    # using on_created and on_destroyed hooks
+    watchers = []
+
+    def on_created(watcher):
+        watchers.append(watcher)
+
+    def on_destroyed(watcher):
+        watchers.remove(watcher)
+
+    try:
+        Watcher.on_created = on_created
+        Watcher.on_destroyed = on_destroyed
+
+        a = reactive([1, 2])
+        called = 0
+
+        def _callback():
+            nonlocal called
+            called += 1
+
+        watch(lambda: len(a), _callback, sync=True)
+        assert called == 0
+        a.append(3)
+        assert called == 1
+        assert len(a) == 3
+
+    finally:
+        Watcher.on_created = None
+        Watcher.on_destroyed = None


### PR DESCRIPTION
Closes #107

This makes it possible to tie the Watcher lifecycle to something global instead of local.