### PR TITLE
Fix bug in legacy qt utility function

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 
 from .init import init, loop_factory

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -20,6 +20,7 @@ class Scheduler:
         "waiting",
         "request_flush",
         "detect_cycles",
+        "timer",
     )
 
     def __init__(self):

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -21,6 +21,7 @@ class Scheduler:
         "request_flush",
         "detect_cycles",
         "timer",
+        "__weakref__",
     )
 
     def __init__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "observ"
-version = "0.14.0"
+version = "0.14.1"
 description = "Reactive state management for Python"
 authors = [
     "Korijn van Golen <korijn@gmail.com>",


### PR DESCRIPTION
Add 'timer' and '__weakref__' to '__slots__' to fix legacy register_qt method.