### PR TITLE
Fix modules/classes/numpy compatibility

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -14,6 +14,13 @@ from itertools import count
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from weakref import WeakSet, ref
 
+try:
+    import numpy as np
+
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
 from .dep import Dep
 from .dict_proxy import DictProxyBase
 from .list_proxy import ListProxyBase
@@ -107,6 +114,8 @@ def traverse(obj, seen=None):
         seen = []
     seen.append(obj)
     for v in val_iter:
+        if has_numpy and isinstance(v, np.ndarray):
+            continue
         if v not in seen:
             traverse(v, seen=seen)
 

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -90,6 +90,8 @@ def traverse(obj, seen=None):
             return
         val_iter = iter(obj)
     else:
+        if inspect.ismodule(obj) or inspect.isclass(obj):
+            return
         obj_attrs = get_object_attrs(obj)
         if not obj_attrs:
             return

--- a/tests/test_object_proxy.py
+++ b/tests/test_object_proxy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from observ import reactive, to_raw
+from observ import reactive, to_raw, watch
 from observ.object_proxy import ObjectProxy, ReadonlyObjectProxy
 from observ.object_utils import get_class_slots, get_object_attrs
 from observ.proxy import proxy
@@ -100,6 +100,13 @@ def test_usage_numpy():
     proxy = reactive(arr)
     # not supported
     assert not isinstance(proxy, ObjectProxy)
+
+
+@pytest.mark.skipif(not has_numpy, reason=numpy_missing_reason)
+def test_usage_watcher_with_numpy_values():
+    proxy = reactive({"key": np.eye(4)})
+
+    _ = watch(lambda: proxy, lambda: (), deep=True)
 
 
 def test_toraw():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -741,6 +741,20 @@ def test_watch_setdefault_existing_key():
     assert cb.call_count == 1
 
 
+def test_watch_module_does_not_raise():
+    """Check that having modules and classes in the reactive state
+    doesn't fail the deep traversal"""
+    a = reactive({"foo": pytest, "bar": WrongNumberOfArgumentsError})
+    cb = Mock()
+
+    watcher = watch(lambda: a, cb, sync=True, deep=True)  # noqa: F841
+
+    assert cb.call_count == 0
+
+    a["baz"] = "foo"
+    assert cb.call_count == 1
+
+
 def test_use_weird_types_as_value():
     # TypeError: bad argument type for built-in operation
     # Might happen with types that can't be compare to None


### PR DESCRIPTION
Having modules, classes or numpy arrays in reactive state in combination with deep watchers throwed exceptions. This makes sure they are skipped.