### PR TITLE
Make sure proxies are slotted properly

### DIFF
--- a/observ/dict_proxy.py
+++ b/observ/dict_proxy.py
@@ -51,6 +51,8 @@ dict_traps = {
 
 
 class DictProxyBase(Proxy[dict]):
+    __slots__ = ()
+
     def _orphaned_keydeps(self):
         return set(proxy_db.attrs(self)["keydep"].keys()) - set(self.__target__.keys())
 
@@ -64,12 +66,16 @@ def readonly_dict_proxy_init(self, target, shallow=False, **kwargs):
 DictProxy = type(
     "DictProxy",
     (DictProxyBase,),
-    construct_methods_traps_dict(dict, dict_traps, trap_map),
+    {
+        "__slots__": (),
+        **construct_methods_traps_dict(dict, dict_traps, trap_map),
+    },
 )
 ReadonlyDictProxy = type(
     "ReadonlyDictProxy",
     (DictProxyBase,),
     {
+        "__slots__": (),
         "__init__": readonly_dict_proxy_init,
         **construct_methods_traps_dict(dict, dict_traps, trap_map_readonly),
     },

--- a/observ/list_proxy.py
+++ b/observ/list_proxy.py
@@ -45,7 +45,7 @@ list_traps = {
 
 
 class ListProxyBase(Proxy[list]):
-    pass
+    __slots__ = ()
 
 
 def readonly_list_proxy_init(self, target, shallow=False, **kwargs):
@@ -57,12 +57,16 @@ def readonly_list_proxy_init(self, target, shallow=False, **kwargs):
 ListProxy = type(
     "ListProxy",
     (ListProxyBase,),
-    construct_methods_traps_dict(list, list_traps, trap_map),
+    {
+        "__slots__": (),
+        **construct_methods_traps_dict(list, list_traps, trap_map),
+    },
 )
 ReadonlyListProxy = type(
     "ReadonlyListProxy",
     (ListProxyBase,),
     {
+        "__slots__": (),
         "__init__": readonly_list_proxy_init,
         **construct_methods_traps_dict(list, list_traps, trap_map_readonly),
     },

--- a/observ/set_proxy.py
+++ b/observ/set_proxy.py
@@ -54,7 +54,7 @@ set_traps = {
 
 
 class SetProxyBase(Proxy[set]):
-    pass
+    __slots__ = ()
 
 
 def readonly_set_proxy_init(self, target, shallow=False, **kwargs):
@@ -64,12 +64,15 @@ def readonly_set_proxy_init(self, target, shallow=False, **kwargs):
 
 
 SetProxy = type(
-    "SetProxy", (SetProxyBase,), construct_methods_traps_dict(set, set_traps, trap_map)
+    "SetProxy",
+    (SetProxyBase,),
+    {"__slots__": (), **construct_methods_traps_dict(set, set_traps, trap_map)},
 )
 ReadonlySetProxy = type(
     "ReadonlysetProxy",
     (SetProxyBase,),
     {
+        "__slots__": (),
         "__init__": readonly_set_proxy_init,
         **construct_methods_traps_dict(set, set_traps, trap_map_readonly),
     },

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -267,3 +267,27 @@ def test_dict_subclass_not_wrapped():
     assert not isinstance(p, Proxy)
     assert isinstance(raw, dict)
     assert p is raw
+
+
+def test_proxy_is_slotted():
+    some_dict = proxy({1: 1, 2: 2, 3: 3})
+    assert isinstance(some_dict, DictProxy)
+    some_list = proxy([1, 2, 3])
+    assert isinstance(some_list, ListProxy)
+    some_set = proxy({1, 2, 3})
+    assert isinstance(some_set, SetProxy)
+
+    with pytest.raises(
+        AttributeError, match="'DictProxy' object has no attribute 'foo'"
+    ):
+        some_dict.foo = "foo"
+
+    with pytest.raises(
+        AttributeError, match="'ListProxy' object has no attribute 'foo'"
+    ):
+        some_list.foo = "foo"
+
+    with pytest.raises(
+        AttributeError, match="'SetProxy' object has no attribute 'foo'"
+    ):
+        some_set.foo = "foo"


### PR DESCRIPTION
All base classes need to have `__slots__` defined in order to actually work.