### PR TITLE
Prevent exception (ValueError) when encountering numpy scalar types

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -114,7 +114,7 @@ def traverse(obj, seen=None):
         seen = []
     seen.append(obj)
     for v in val_iter:
-        if has_numpy and isinstance(v, np.ndarray):
+        if has_numpy and isinstance(v, (np.ndarray, np.generic)):
             continue
         if v not in seen:
             traverse(v, seen=seen)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "observ"
-version = "0.15.1"
+version = "0.15.2"
 description = "Reactive state management for Python"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },

--- a/tests/test_object_proxy.py
+++ b/tests/test_object_proxy.py
@@ -104,7 +104,13 @@ def test_usage_numpy():
 
 @pytest.mark.skipif(not has_numpy, reason=numpy_missing_reason)
 def test_usage_watcher_with_numpy_values():
-    proxy = reactive({"key": np.eye(4)})
+    proxy = reactive(
+        {
+            "key": np.eye(4),
+            "float": np.float64(1.2),
+            "int": np.short(2),
+        }
+    )
 
     _ = watch(lambda: proxy, lambda: (), deep=True)
 


### PR DESCRIPTION
https://numpy.org/doc/1.26/reference/arrays.scalars.html#numpy.generic

Noticed this when trying to get an example from Pygfx running (reactive_rendering.py).

```
  File "./observ/watcher.py", line 119, in traverse
    if v not in seen:
       ^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```