### PR TITLE
Separate benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-name: Performance Benchmarks
+name: Benchmarks
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   benchmark:
-    name: Run performance benchmarks
+    name: Benchmarks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,78 @@
+name: Performance Benchmarks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Run performance benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Need full history for comparisons
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      # Cache benchmark results
+      - name: Cache benchmark results
+        uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: benchmark-results-${{ runner.os }}-${{ github.ref_name }}
+          restore-keys: |
+            benchmark-results-${{ runner.os }}-master
+            benchmark-results-${{ runner.os }}-
+
+      # On master branch: save baseline results
+      - name: Run benchmarks and save baseline
+        if: github.ref == 'refs/heads/master'
+        run: |
+          uv run --no-sync pytest bench \
+            --benchmark-only \
+            --benchmark-autosave \
+            --benchmark-sort=name
+
+      # On PRs: compare against baseline and fail if degraded
+      - name: Run benchmarks and compare
+        if: github.event_name == 'pull_request'
+        run: |
+          # Get the latest baseline ID
+          BASELINE=$(ls -1 .benchmarks/*/0*.json 2>/dev/null | tail -1 | grep -oP '\d{4}(?=_)')
+
+          if [ -z "$BASELINE" ]; then
+            echo "No baseline found, running benchmarks without comparison"
+            uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-autosave \
+              --benchmark-sort=name
+          else
+            echo "Comparing against baseline: $BASELINE"
+            uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-compare=$BASELINE \
+              --benchmark-compare-fail=mean:5% \
+              --benchmark-sort=name
+          fi
+
+      # Save benchmark results as artifact for PRs
+      - name: Upload benchmark results
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: .benchmarks/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,17 +26,16 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      # Cache benchmark results
-      - name: Cache benchmark results
-        uses: actions/cache@v4
+      # Restore benchmark baseline (read-only for PRs)
+      - name: Restore benchmark baseline
+        uses: actions/cache/restore@v4
         with:
           path: .benchmarks
-          key: benchmark-results-${{ runner.os }}-${{ github.ref_name }}
+          key: benchmark-baseline-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            benchmark-results-${{ runner.os }}-master
-            benchmark-results-${{ runner.os }}-
+            benchmark-baseline-${{ runner.os }}-
 
-      # On master branch: save baseline results
+      # On master: save baseline results
       - name: Run benchmarks and save baseline
         if: github.ref == 'refs/heads/master'
         run: |
@@ -44,6 +43,14 @@ jobs:
             --benchmark-only \
             --benchmark-autosave \
             --benchmark-sort=name
+
+      # On master: cache the new baseline results
+      - name: Save benchmark baseline
+        if: github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: .benchmarks
+          key: benchmark-baseline-${{ runner.os }}-${{ github.sha }}
 
       # On PRs: compare against baseline and fail if degraded
       - name: Run benchmarks and compare

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0  # Need full history for comparisons
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,9 +31,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .benchmarks
-          key: benchmark-baseline-${{ runner.os }}-${{ github.sha }}
-          restore-keys: |
-            benchmark-baseline-${{ runner.os }}-
+          key: benchmark-baseline-3.14-${{ runner.os }}
 
       # On master: save baseline results
       - name: Run benchmarks and save baseline
@@ -50,7 +48,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .benchmarks
-          key: benchmark-baseline-${{ runner.os }}-${{ github.sha }}
+          key: benchmark-baseline-3.14-${{ runner.os }}
 
       # On PRs: compare against baseline and fail if degraded
       - name: Run benchmarks and compare

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync
 
       # Cache benchmark results
       - name: Cache benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,28 +49,14 @@ jobs:
       - name: Run benchmarks and compare
         if: github.event_name == 'pull_request'
         run: |
-          # Get the latest baseline ID
-          BASELINE=$(ls -1 .benchmarks/*/0*.json 2>/dev/null | tail -1 | grep -oP '\d{4}(?=_)')
-
-          if [ -z "$BASELINE" ]; then
-            echo "No baseline found, running benchmarks without comparison"
-            uv run --no-sync pytest bench \
-              --benchmark-only \
-              --benchmark-autosave \
-              --benchmark-sort=name
-          else
-            echo "Comparing against baseline: $BASELINE"
-            uv run --no-sync pytest bench \
-              --benchmark-only \
-              --benchmark-compare=$BASELINE \
-              --benchmark-compare-fail=mean:5% \
-              --benchmark-sort=name
+          if [ -z "$(uv run --no-sync pytest-benchmark list)" ]; then
+            echo "No baseline found, skip the benchmark"
+            exit
           fi
 
-      # Save benchmark results as artifact for PRs
-      - name: Upload benchmark results
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results
-          path: .benchmarks/
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-compare \
+              --benchmark-compare-fail=mean:5% \
+              --benchmark-sort=name
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
         run: uv run --no-sync pytest -v --cov=observ --cov-report=term-missing tests
         env:
           QT_QPA_PLATFORM: offscreen
-      - name: Bench
-        run: uv run --no-sync pytest -v bench
 
   build:
     name: Build and test wheel


### PR DESCRIPTION
Run benchmark as separate workflow and compare benchmark on PRs with latest from master (if available). Uses the cache action to store the results.