### PR TITLE
Fix for __version__ being different from packaged version

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -1,4 +1,6 @@
-__version__ = "0.15.0"
+from importlib.metadata import version
+
+__version__ = version("observ")
 
 
 from .init import init, loop_factory


### PR DESCRIPTION
This prevents the version in `__init__` to be different from the package version.