### PR TITLE
Prevent wrapping subclasses of lists and sets

### DIFF
--- a/observ/list_proxy.py
+++ b/observ/list_proxy.py
@@ -74,7 +74,7 @@ ReadonlyListProxy = type(
 
 
 def type_test(target):
-    return isinstance(target, list)
+    return type(target) is list
 
 
 TYPE_LOOKUP[type_test] = (ListProxy, ReadonlyListProxy)

--- a/observ/set_proxy.py
+++ b/observ/set_proxy.py
@@ -80,7 +80,7 @@ ReadonlySetProxy = type(
 
 
 def type_test(target):
-    return isinstance(target, set)
+    return type(target) is set
 
 
 TYPE_LOOKUP[type_test] = (SetProxy, ReadonlySetProxy)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -269,6 +269,28 @@ def test_dict_subclass_not_wrapped():
     assert p is raw
 
 
+def test_list_subclass_not_wrapped():
+    class Custom(list):
+        pass
+
+    raw = Custom([0, 1, 2])
+    p = proxy(raw)
+    assert not isinstance(p, Proxy)
+    assert isinstance(raw, list)
+    assert p is raw
+
+
+def test_set_subclass_not_wrapped():
+    class Custom(set):
+        pass
+
+    raw = Custom([1, 2, 3])
+    p = proxy(raw)
+    assert not isinstance(p, Proxy)
+    assert isinstance(raw, set)
+    assert p is raw
+
+
 def test_proxy_is_slotted():
     some_dict = proxy({1: 1, 2: 2, 3: 3})
     assert isinstance(some_dict, DictProxy)


### PR DESCRIPTION
Given the removal of wrapping objects in #138 and restricting wrapping of dicts to 'pure' dicts in #130, here is the follow-up that I mentioned there. This makes sure only pure plain objects will be wrapped.