### PR TITLE
Optimize traverse method

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,6 @@ jobs:
 
       # On PRs: run benchmarks twice (PR code vs master code) and compare
       - name: Run benchmarks on master code (baseline)
-        continue-on-error: true
         run: |
           # Checkout master version of observ directory
           git fetch origin master
@@ -35,13 +34,12 @@ jobs:
           uv run --no-sync pytest bench \
               --benchmark-only \
               --benchmark-save=master \
-              --benchmark-sort=mean
+              --benchmark-sort=mean || true
 
           # Restore PR code
           git checkout HEAD -- observ/
 
-      - name: Run benchmarks on PR code and compare
-        run: |
+          # Run benchmarks on PR code and compare
           uv run --no-sync pytest bench \
               --benchmark-only \
               --benchmark-compare \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,42 +26,37 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      # Restore benchmark baseline (read-only for PRs)
-      - name: Restore benchmark baseline
-        uses: actions/cache/restore@v4
-        with:
-          path: .benchmarks
-          key: benchmark-baseline-3.14-${{ runner.os }}
-
-      # On master: save baseline results
-      - name: Run benchmarks and save baseline
+      # On master: just run benchmarks
+      - name: Run benchmarks
         if: github.ref == 'refs/heads/master'
         run: |
           uv run --no-sync pytest bench \
             --benchmark-only \
-            --benchmark-autosave \
             --benchmark-sort=name
 
-      # On master: cache the new baseline results
-      - name: Save benchmark baseline
-        if: github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
-        with:
-          path: .benchmarks
-          key: benchmark-baseline-3.14-${{ runner.os }}
-
-      # On PRs: compare against baseline and fail if degraded
-      - name: Run benchmarks and compare
+      # On PRs: run benchmarks twice (PR code vs master code) and compare
+      - name: Run benchmarks on master code (baseline)
         if: github.event_name == 'pull_request'
         run: |
-          if [ -z "$(uv run --no-sync pytest-benchmark list)" ]; then
-            echo "No baseline found, skip the benchmark"
-            exit
-          fi
+          # Checkout master version of observ directory
+          git fetch origin master
+          git checkout origin/master -- observ/
 
+          # Run benchmarks with master code as baseline
+          uv run --no-sync pytest bench \
+              --benchmark-only \
+              --benchmark-save=master \
+              --benchmark-sort=mean
+
+          # Restore PR code
+          git checkout HEAD -- observ/
+
+      - name: Run benchmarks on PR code and compare
+        if: github.event_name == 'pull_request'
+        run: |
           uv run --no-sync pytest bench \
               --benchmark-only \
               --benchmark-compare \
               --benchmark-compare-fail=mean:5% \
-              --benchmark-sort=name
+              --benchmark-sort=mean
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,4 +54,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Benchmarks
-          path: .benchmarks
+          path: .benchmarks/
+          include-hidden-files: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,6 @@
 name: Benchmarks
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -21,22 +18,14 @@ jobs:
       - name: Set up Python 3.14
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: "3.14"
 
       - name: Install dependencies
         run: uv sync
 
-      # On master: just run benchmarks
-      - name: Run benchmarks
-        if: github.ref == 'refs/heads/master'
-        run: |
-          uv run --no-sync pytest bench \
-            --benchmark-only \
-            --benchmark-sort=name
-
       # On PRs: run benchmarks twice (PR code vs master code) and compare
       - name: Run benchmarks on master code (baseline)
-        if: github.event_name == 'pull_request'
+        continue-on-error: true
         run: |
           # Checkout master version of observ directory
           git fetch origin master
@@ -52,11 +41,17 @@ jobs:
           git checkout HEAD -- observ/
 
       - name: Run benchmarks on PR code and compare
-        if: github.event_name == 'pull_request'
         run: |
           uv run --no-sync pytest bench \
               --benchmark-only \
               --benchmark-compare \
               --benchmark-compare-fail=mean:5% \
+              --benchmark-save=branch \
               --benchmark-sort=mean
 
+      - name: Upload benchmarks
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Benchmarks
+          path: .benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
         run: uv sync
 
       # On PRs: run benchmarks twice (PR code vs master code) and compare
-      - name: Run benchmarks on master code (baseline)
+      - name: Run benchmarks
         run: |
           # Checkout master version of observ directory
           git fetch origin master

--- a/bench/test_traverse.py
+++ b/bench/test_traverse.py
@@ -1,0 +1,148 @@
+"""
+Benchmarks for different traverse implementations.
+
+These benchmarks test various optimization strategies for the traverse function
+which is used for deep watching of reactive data structures.
+"""
+
+import pytest
+
+from observ import reactive
+from observ.watcher import traverse
+
+
+def create_shallow_structure(size=100):
+    """Create a flat dictionary with many keys."""
+    data = {f"key_{i}": f"value_{i}" for i in range(size)}
+    return reactive(data)
+
+
+def create_deep_structure(depth=100):
+    """Create a deeply nested dictionary."""
+    obj = {"value": "leaf"}
+    for i in range(depth):
+        obj = {"level": i, "child": obj}
+    return reactive(obj)
+
+
+def create_wide_structure(breadth=10, depth=3):
+    """Create a wide tree structure."""
+
+    def make_tree(current_depth):
+        if current_depth >= depth:
+            return {"leaf": True}
+        return {f"child_{i}": make_tree(current_depth + 1) for i in range(breadth)}
+
+    data = make_tree(0)
+    return reactive(data)
+
+
+def create_list_structure(size=100):
+    """Create a list with nested lists."""
+    data = [{"index": i, "data": [i, i + 1, i + 2]} for i in range(size)]
+    return reactive(data)
+
+
+def create_cyclic_structure(use_reactive=False):
+    """Create a structure with cycles."""
+    obj = {"name": "root"}
+    child = {"name": "child", "parent": obj}
+    obj["child"] = child
+    obj["self"] = obj
+    return reactive(obj)
+
+
+def create_mixed_structure(size=50):
+    """Create a structure mixing dicts, lists, and sets."""
+    data = {
+        "dict": {f"k{i}": i for i in range(size)},
+        "list": [i for i in range(size)],
+        "nested": [{"index": i, "values": [i * 2, i * 3]} for i in range(size // 5)],
+        "set": {i for i in range(size)},
+    }
+    return reactive(data)
+
+
+def create_large_flat_list(size=1000):
+    """Create a large flat list."""
+    data = list(range(size))
+    return reactive(data)
+
+
+def create_matrix_structure(rows=50, cols=50):
+    """Create a matrix-like structure (list of lists)."""
+    data = [[i * cols + j for j in range(cols)] for i in range(rows)]
+    return reactive(data)
+
+
+# Parametrize all tests with different implementations
+@pytest.mark.benchmark(group="traverse_shallow")
+def test_traverse_shallow(benchmark):
+    """Benchmark traverse on shallow structure (many keys at one level)
+    with reactive proxies."""
+    structure = create_shallow_structure(size=100)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_deep")
+def test_traverse_deep(benchmark):
+    """Benchmark traverse on deep structure (linear chain) with reactive proxies."""
+    structure = create_deep_structure(depth=100)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_wide")
+def test_traverse_wide(benchmark):
+    """Benchmark traverse on wide tree structure with reactive proxies."""
+    structure = create_wide_structure(breadth=10, depth=3)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_list")
+def test_traverse_list(benchmark):
+    """Benchmark traverse on list structure with reactive proxies."""
+    structure = create_list_structure(size=100)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_cyclic")
+def test_traverse_cyclic(benchmark):
+    """Benchmark traverse on cyclic structure with reactive proxies."""
+    structure = create_cyclic_structure(use_reactive=True)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_mixed")
+def test_traverse_mixed(benchmark):
+    """Benchmark traverse on mixed structure with reactive proxies."""
+    structure = create_mixed_structure(size=50)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_large_flat")
+def test_traverse_large_flat_list(benchmark):
+    """Benchmark traverse on large flat list with reactive proxies."""
+    structure = create_large_flat_list(size=1000)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_matrix")
+def test_traverse_matrix(benchmark):
+    """Benchmark traverse on matrix structure (list of lists) with reactive proxies."""
+    structure = create_matrix_structure(rows=50, cols=50)
+    benchmark(traverse, structure)
+
+
+# Stress test with very large structures using reactive proxies
+@pytest.mark.benchmark(group="traverse_stress")
+def test_traverse_stress_large_shallow(benchmark):
+    """Stress test with large shallow structure using reactive proxies."""
+    structure = create_shallow_structure(size=1000)
+    benchmark(traverse, structure)
+
+
+@pytest.mark.benchmark(group="traverse_stress")
+def test_traverse_stress_large_mixed(benchmark):
+    """Stress test with large mixed structure using reactive proxies."""
+    structure = create_mixed_structure(size=200)
+    benchmark(traverse, structure)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,4 @@ select = [
 
 [tool.pytest.ini_options]
 addopts = "--benchmark-columns='mean, stddev, rounds'"
-timeout = 3
+# timeout = 3

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -8,6 +8,13 @@ from observ.list_proxy import ListProxy
 from observ.proxy import Proxy
 from observ.watcher import WrongNumberOfArgumentsError
 
+try:
+    import numpy as np
+
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
 
 def test_usage_dict():
     a = reactive({"foo": "bar"})
@@ -751,6 +758,20 @@ def test_use_weird_types_as_value():
 
     a = reactive(dict())
     a["foo"] = Foo(3)
+
+
+@pytest.mark.skipif(not has_numpy, reason="numpy is not installed")
+def test_use_skips_numpy():
+    cb = Mock()
+    a = reactive({"foo": np.array([1, 0, 0])})
+
+    # Check that watching a structure with numpy arrays
+    # doesn't raise a ValueError
+    watcher = watch(a, cb, deep=True, sync=True)  # noqa: F841
+
+    a["foo"][1] = 1
+
+    assert cb.call_count == 0
 
 
 def test_watch_reactive_object():


### PR DESCRIPTION
Try to optimize the traverse method by using a set with object ids which should yield faster lookups. However, this time also keep all the encountered objects referenced in a list so that for the duration of the method the object ids will not be re-used. See #71 for history on this.

In order to compare the performance to the master branch, I adjusted the benchmark workflow to run the benchmarks from the PR also with the code from master. This way the cache is not needed and any new benchmarks can still be compared with the code from master.