### PR TITLE
Support stopping a watcher by calling it

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -141,6 +141,7 @@ class Watcher(Generic[T]):
         "_new_deps",
         "_number_of_callback_args",
         "_tasks",
+        "active",
         "callback",
         "callback_async",
         "deep",
@@ -171,6 +172,7 @@ class Watcher(Generic[T]):
         callback: Method to call when value has changed
         """
         self.id = next(_ids)
+        self.active = True
         if callable(fn):
             if is_bound_method(fn):
                 self.fn = weak(fn.__self__, fn.__func__)
@@ -229,6 +231,8 @@ class Watcher(Generic[T]):
 
     def run(self) -> None:
         """Called by scheduler"""
+        if not self.active:
+            return
         value = self.get()
         if self.deep or isinstance(value, Container) or value != self.value:
             old_value = self.value

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,7 +1,5 @@
 from unittest.mock import Mock
 
-import pytest
-
 from observ import reactive, scheduler, watch
 
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -7,8 +7,9 @@ def test_watcher_active(noop_request_flush):
     a = reactive({"foo": "bar"})
     callback = Mock()
 
-    watcher = watch(lambda: a["foo"], callback, immediate=False)
-    assert watcher.active
+    unwatch = watch(lambda: a["foo"], callback, immediate=False)
+
+    assert callable(unwatch)
 
     callback.assert_not_called()
 
@@ -20,7 +21,8 @@ def test_watcher_active(noop_request_flush):
     callback.reset_mock()
 
     a["foo"] = "qux"
-    watcher.active = False
+    # Call the watcher to stop the watcher
+    unwatch()
 
     scheduler.flush()
     callback.assert_not_called()
@@ -53,11 +55,11 @@ def test_watcher_removed_icw_active(noop_request_flush):
             )
 
         while len(watchers) > new:
-            watcher = watchers.pop()
-            # Here the watcher is deactivated to make sure it won't
+            unwatch = watchers.pop()
+            # Here the watcher is stopped to make sure it won't
             # trigger and tries to get a non-existing value from the
             # watched array
-            watcher.active = False
+            unwatch()
 
     _length_watcher = watch(
         lambda: len(a["foo"]),

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,87 @@
+from unittest.mock import Mock
+
+import pytest
+
+from observ import reactive, scheduler, watch
+
+
+def test_watcher_active(noop_request_flush):
+    a = reactive({"foo": "bar"})
+    callback = Mock()
+
+    watcher = watch(lambda: a["foo"], callback, immediate=False)
+    assert watcher.active
+
+    callback.assert_not_called()
+
+    a["foo"] = "baz"
+    scheduler.flush()
+
+    callback.assert_called_once()
+
+    callback.reset_mock()
+
+    a["foo"] = "qux"
+    watcher.active = False
+
+    scheduler.flush()
+    callback.assert_not_called()
+
+
+def test_watcher_removed_icw_active(noop_request_flush):
+    """
+    This example is a basic reconstruction of what happens inside collagraph
+    when a list of elements is rendered and watchers are created for items
+    within a reactive list.
+    """
+    a = reactive({"foo": ["bar", "baz"]})
+
+    callback_args = []
+
+    def callback(arg):
+        callback_args.append(arg)
+
+    watchers = []
+
+    def create_watchers(new):
+        for i in range(len(watchers), new):
+            watchers.append(
+                watch(
+                    lambda i=i: a["foo"][i],
+                    lambda new, old, /, i=i: callback(i),
+                    deep=True,
+                    immediate=True,
+                )
+            )
+
+        while len(watchers) > new:
+            watcher = watchers.pop()
+            # Here the watcher is deactivated to make sure it won't
+            # trigger and tries to get a non-existing value from the
+            # watched array
+            watcher.active = False
+
+    _length_watcher = watch(
+        lambda: len(a["foo"]),
+        create_watchers,
+        deep=False,
+        immediate=True,
+    )
+
+    scheduler.flush()
+
+    assert callback_args == [0, 1]
+    callback_args.clear()
+
+    a["foo"].pop()
+
+    # Popping the last item of the array will trigger the removal of the
+    # last watcher. However, the watcher needs to be deactivated to make
+    # sure it won't try to get a value from a["foo"] that doesn't exist
+    # anymore, resulting in an IndexError
+    scheduler.flush()
+    # Note: before the active property was there, the work-around was the following:
+    #     watcher.fn = lambda: ()
+    #     watcher.callback = None
+
+    assert callback_args == [0]


### PR DESCRIPTION
This can help with disabling watchers at critical moments, for example right before they are removed. This alleviates the need for work-arounds such as installing a dummy fn property and clearing the callback property.