### PR TITLE
Optimize GC callback

### DIFF
--- a/observ/proxy_db.py
+++ b/observ/proxy_db.py
@@ -142,4 +142,5 @@ class ProxyDb:
             return None
 
 
+# Create a global proxy collection
 proxy_db = ProxyDb()


### PR DESCRIPTION
This PR changes a few things:

* Adds early exits for GC collection generations 0 and 1: especially gen 0 trigger almost constantly and it benefits runtime greatly if it can do all that work without having to execute Python callbacks like this one
* Micro-optimized the rest of the logic so it has the absolute minimum amount of Python steps to perform - as most of the time when this callback runs it will have nothing to do, we want to find out as quickly as we can

Note - the benefits are pretty tricky to see in a benchmark. It's more noticeable in long running usage.