### PR TITLE
Fix for deletion of keys

### DIFF
--- a/observ/traps.py
+++ b/observ/traps.py
@@ -146,12 +146,18 @@ def delete_key_trap(method, obj_cls):
 
     @wraps(fn)
     def trap(self, *args, **kwargs):
-        retval = fn(self.__target__, *args, **kwargs)
         key = args[0]
         attrs = proxy_db.attrs(self)
-        attrs["dep"].notify()
-        attrs["keydep"][key].notify()
-        del attrs["keydep"][key]
+        key_existed = key in self.__target__
+        retval = fn(self.__target__, *args, **kwargs)
+        if key_existed:
+            attrs["dep"].notify()
+            if key in attrs["keydep"]:
+                keydep = attrs["keydep"][key]
+                keydep.notify()
+                # Only delete keydep if no subscribers are interested in this key
+                if not keydep._subs:
+                    del attrs["keydep"][key]
         return retval
 
     return trap

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -359,4 +359,26 @@ def test_dict_delete_keynotify():
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         mocks[key].update.assert_called_once()
-        assert len(proxy_db.attrs(coll)["keydep"]) == 0
+        # keydep entries are preserved so watchers can be notified when the key is re-added
+        assert key in proxy_db.attrs(coll)["keydep"]
+
+
+def test_dict_pop_with_default():
+    """Test that dict.pop with a default value works for missing keys."""
+    coll = DictProxy({2: 3})
+    mock = Mock()
+    proxy_db.attrs(coll)["dep"].add_sub(mock)
+
+    # Pop existing key - should notify and return value
+    result = coll.pop(2, "default")
+    assert result == 3
+    mock.update.assert_called_once()
+    # keydep is cleaned up when there are no subscribers
+    assert 2 not in proxy_db.attrs(coll)["keydep"]
+
+    # Pop missing key with default - should return default without error
+    mock.reset_mock()
+    result = coll.pop(999, "default")
+    assert result == "default"
+    # Should not notify since nothing changed
+    mock.update.assert_not_called()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -359,7 +359,8 @@ def test_dict_delete_keynotify():
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         mocks[key].update.assert_called_once()
-        # keydep entries are preserved so watchers can be notified when the key is re-added
+        # keydep entries are preserved so watchers
+        # can be notified when the key is re-added
         assert key in proxy_db.attrs(coll)["keydep"]
 
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -646,6 +646,16 @@ def test_watch_get_non_existing():
 
     assert watcher.value is True
 
+    # Delete the key
+    del a["foo"]
+
+    assert watcher.value is False
+
+    # Then re-add the key, which should trigger the watcher again
+    a["foo"] = True
+
+    assert watcher.value is True
+
 
 def test_watch_get_non_existing_dict():
     a = reactive(dict())
@@ -716,6 +726,43 @@ def test_watch_setdefault_existing_key():
 
     some_list.append("bar")
     assert cb.call_count == 1
+
+
+def test_dict_pop_with_default():
+    from observ import reactive, watch
+
+    mock = Mock()
+
+    state = reactive({"a": "a"})
+    watcher = watch(
+        lambda: state.get("b"),
+        mock,
+        sync=True,
+    )
+
+    mock.assert_not_called()
+    state.pop("b", "c")
+    mock.assert_not_called()
+
+    # Set a value for 'b'
+    state["b"] = "b"
+    mock.assert_called_once_with("b")
+    mock.reset_mock()
+
+    # pop 'b'
+    result = state.pop("b", "c")
+    assert result == "b"
+    mock.assert_called_once_with(None)
+    mock.reset_mock()
+
+    # pop 'b' again, should now return default
+    result = state.pop("b", "c")
+    assert result == "c"
+    mock.assert_not_called()
+
+    # Setting a value for 'b' again should trigger the watcher
+    state["b"] = "b"
+    mock.assert_called_once_with("b")
 
 
 def test_watch_module_does_not_raise():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -734,7 +734,7 @@ def test_dict_pop_with_default():
     mock = Mock()
 
     state = reactive({"a": "a"})
-    watcher = watch(
+    watcher = watch(  # noqa: F841
         lambda: state.get("b"),
         mock,
         sync=True,


### PR DESCRIPTION
Fixes #134 

There was a problem with `dict.pop(key, default)`, which threw a KeyError from the delete_key_trap. In order to fix this, it now checks before notifying whether the key actually existed in the dict before trying to delete the key to decide if it should notify any deps. Because if the key wasn't there in the first place, then there is no need to notify.

While investigating, I found another problem with the `.get(key)` method that after an existing key has been deleted, then any watcher using `.get(key)` will not be notified anymore, because the `keydep` had been removed. Now it includes a check to see if there are still any subscribers for this key, because if so: then the keydep should not be removed yet.