### PR TITLE
Improve exception output when exceptions occur in callbacks

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -288,12 +288,18 @@ class Watcher(Generic[T]):
                 maybe_coro = self._run_callback(new)
                 self._number_of_callback_args = 1
             except WrongNumberOfArgumentsError:
+                pass
+
+            if self._number_of_callback_args is None:
                 try:
                     maybe_coro = self._run_callback()
                     self._number_of_callback_args = 0
                 except WrongNumberOfArgumentsError:
-                    maybe_coro = self._run_callback(new, old)
-                    self._number_of_callback_args = 2
+                    pass
+
+            if self._number_of_callback_args is None:
+                maybe_coro = self._run_callback(new, old)
+                self._number_of_callback_args = 2
 
         if self.callback_async and maybe_coro:
             loop = asyncio.get_event_loop()

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -16,6 +16,20 @@ except ImportError:
     has_numpy = False
 
 
+def exception_chain(exc: Exception):
+    """
+    Return a unwrapped list of exceptions in a chain.
+
+    When an exception is raised within another exception,
+    then it will be stored in the `__context__` attribute.
+    """
+    result = []
+    while exc is not None:
+        result.append(exc)
+        exc = exc.__context__
+    return result
+
+
 def test_usage_dict():
     a = reactive({"foo": "bar"})
     called = 0
@@ -247,6 +261,54 @@ def test_callback_signatures():
         )
     assert called == 4
     assert not isinstance(e, WrongNumberOfArgumentsError)
+
+
+def test_number_of_arguments_error_is_not_nested():
+    def cb(new, old, too_much):
+        pass
+
+    state = reactive({"foo": "bar"})
+
+    _watcher = watch(
+        lambda: state.get("foo"),
+        cb,
+        sync=True,
+        deep=True,
+    )
+
+    with pytest.raises(WrongNumberOfArgumentsError) as exc:
+        state["foo"] = "baz"
+
+    chain = exception_chain(exc.value)
+
+    # Before, the exceptions used to be nested into each other,
+    # leading to really messy stack traces
+    assert len(chain) == 2
+    assert isinstance(chain[0], WrongNumberOfArgumentsError)
+    assert isinstance(chain[1], TypeError)
+
+
+def test_number_of_arguments_error_not_in_chain_on_actual_exception():
+    def cb(new, old):
+        raise RuntimeError("Oops")
+
+    state = reactive({"foo": "bar"})
+
+    _watcher = watch(
+        lambda: state.get("foo"),
+        cb,
+        sync=True,
+        deep=True,
+    )
+    with pytest.raises(RuntimeError) as exc:
+        state["foo"] = "baz"
+
+    # Before, when an actual exception was raised from within the
+    # callback, the exceptions used to be nested into 2 or 3
+    # WrongNumberOfArgumentsErrors, which was very annoying to read
+    chain = exception_chain(exc.value)
+    assert len(chain) == 1
+    assert isinstance(chain[0], RuntimeError)
 
 
 def test_dict_keys():


### PR DESCRIPTION
Prevent exceptions from being nested in a bunch of WrongNumberOfArgumentsErrors. This should clean up the traceback a lot when exceptions occur within the callback.

Just for demonstration purposes:
```python
>>> from observ import reactive, watch
>>> def cb(new, old):
...     raise RuntimeError("Oops")
...
>>> state = reactive({"foo":"bar"})
>>> watch(state, cb, deep=True, sync=True, immediate=True)
Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 317, in _run_callback
    return self.callback(*args)
           ~~~~~~~~~~~~~^^^^^^^
TypeError: cb() missing 1 required positional argument: 'old'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 288, in run_callback
    maybe_coro = self._run_callback(new)
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 335, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: cb() missing 1 required positional argument: 'old'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 317, in _run_callback
    return self.callback(*args)
           ~~~~~~~~~~~~~^^^^^^^
TypeError: cb() missing 2 required positional arguments: 'new' and 'old'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 292, in run_callback
    maybe_coro = self._run_callback()
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 335, in _run_callback
    raise WrongNumberOfArgumentsError(str(e)) from e
observ.watcher.WrongNumberOfArgumentsError: cb() missing 2 required positional arguments: 'new' and 'old'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    watch(state, cb, deep=True, sync=True, immediate=True)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 45, in watch
    watcher.run_callback(watcher.value, None)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 295, in run_callback
    maybe_coro = self._run_callback(new, old)
  File ".venv/lib/python3.13/site-packages/observ/watcher.py", line 317, in _run_callback
    return self.callback(*args)
           ~~~~~~~~~~~~~^^^^^^^
  File "<python-input-1>", line 2, in cb
    raise RuntimeError("Oops")
RuntimeError: Oops
>>>
```

This is now:
```python
>>> from observ import reactive, watch
>>> def cb(new, old):
...     raise RuntimeError("Better")
...
>>> state = reactive({})
>>> watch(state, cb, deep=True, sync=True, immediate=True)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    watch(state, cb, deep=True, sync=True, immediate=True)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./observ/observ/watcher.py", line 45, in watch
    watcher.run_callback(watcher.value, None)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "./observ/observ/watcher.py", line 301, in run_callback
    maybe_coro = self._run_callback(new, old)
  File "./observ/observ/watcher.py", line 323, in _run_callback
    return self.callback(*args)
           ~~~~~~~~~~~~~^^^^^^^
  File "<python-input-1>", line 2, in cb
    raise RuntimeError("Better")
RuntimeError: Better
>>>
```
