### PR TITLE
Don't clean up keydeps at all, like Vue

### DIFF
--- a/observ/traps.py
+++ b/observ/traps.py
@@ -135,7 +135,6 @@ def delete_trap(method, obj_cls):
         attrs["dep"].notify()
         for key in self._orphaned_keydeps():
             attrs["keydep"][key].notify()
-            del attrs["keydep"][key]
         return retval
 
     return trap
@@ -152,12 +151,7 @@ def delete_key_trap(method, obj_cls):
         retval = fn(self.__target__, *args, **kwargs)
         if key_existed:
             attrs["dep"].notify()
-            if key in attrs["keydep"]:
-                keydep = attrs["keydep"][key]
-                keydep.notify()
-                # Only delete keydep if no subscribers are interested in this key
-                if not keydep._subs:
-                    del attrs["keydep"][key]
+            attrs["keydep"][key].notify()
         return retval
 
     return trap

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -334,7 +334,7 @@ def test_dict_delete_notify():
             proxy_db.attrs(coll)["keydep"][key].add_sub(new_mock(key))
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
-        assert len(proxy_db.attrs(coll)["keydep"]) == 0
+        assert len(proxy_db.attrs(coll)["keydep"]) == 1
 
 
 def test_dict_delete_keynotify():
@@ -374,8 +374,6 @@ def test_dict_pop_with_default():
     result = coll.pop(2, "default")
     assert result == 3
     mock.update.assert_called_once()
-    # keydep is cleaned up when there are no subscribers
-    assert 2 not in proxy_db.attrs(coll)["keydep"]
 
     # Pop missing key with default - should return default without error
     mock.reset_mock()

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -30,17 +30,17 @@ def test_deps_copy():
 
 
 def test_deps_delete():
-    # test that dep objects are removed on delete
+    # test that dep objects are _not_ removed on delete
     state = reactive({"foo": 5, "bar": 6})
 
     state["baz"] = 5
     assert len(proxy_db.attrs(state)["keydep"]) == 3
 
     del state["baz"]
-    assert len(proxy_db.attrs(state)["keydep"]) == 2
+    assert len(proxy_db.attrs(state)["keydep"]) == 3
 
     state.popitem()
-    assert len(proxy_db.attrs(state)["keydep"]) == 1
+    assert len(proxy_db.attrs(state)["keydep"]) == 3
 
     state.clear()
-    assert len(proxy_db.attrs(state)["keydep"]) == 0
+    assert len(proxy_db.attrs(state)["keydep"]) == 3


### PR DESCRIPTION
Just to share a bit of context: I've looked through the [reactivity core](https://github.com/vuejs/core/tree/main/packages/reactivity) package and tried to map the types in observ to the types in Vue. The `targetMap` in Vue maps to the `proxy_db` (mapping objects to Deps) and the I've tried to figure out what Vue does when a key is removed, but the only calls `trigger` (`notify` in observ). No explicit cleanup is done: it simply depends on the objects' life cycle.

This PR is the answer to the conversation in #153 .