### PR TITLE
Use 'init' method and fix progress bar display

### DIFF
--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -107,16 +107,16 @@ class Controls(QWidget):
 
         self.thread.start()
 
+        def progress(x):
+            self.state["progress"] = x
+
+        def bump(x):
+            self.state["clicked"] += x * 0.5
+
         self.button.setEnabled(False)
         self.thread.finished.connect(lambda: self.button.setEnabled(True))
-        self.worker.result.connect(self.on_result)
-        self.worker.progress.connect(self.on_progress)
-
-    def on_progress(self, x):
-        self.state["progress"] = x
-
-    def on_result(self, x):
-        self.state["clicked"] += x * 0.5
+        self.worker.result.connect(bump)
+        self.worker.progress.connect(progress)
 
     def on_reset_clicked(self):
         self.state["clicked"] = 0

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -11,7 +11,7 @@ based on the state changes.
 from time import sleep
 
 from PySide6 import QtAsyncio
-from PySide6.QtCore import QObject, QThread, Signal, Slot
+from PySide6.QtCore import QObject, QThread, Signal
 from PySide6.QtWidgets import (
     QApplication,
     QLabel,
@@ -112,11 +112,9 @@ class Controls(QWidget):
         self.worker.result.connect(self.on_result)
         self.worker.progress.connect(self.on_progress)
 
-    @Slot(int)
     def on_progress(self, x):
         self.state["progress"] = x
 
-    @Slot(int)
     def on_result(self, x):
         self.state["clicked"] += x * 0.5
 

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -8,11 +8,10 @@ and updates the label whenever a computed property
 based on the state changes.
 """
 
-import asyncio
 from time import sleep
 
 from PySide6 import QtAsyncio
-from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtCore import QObject, QThread, Signal, Slot
 from PySide6.QtWidgets import (
     QApplication,
     QLabel,
@@ -22,7 +21,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from observ import reactive, scheduler, watch
+from observ import init, reactive, watch
 
 
 class Display(QWidget):
@@ -108,16 +107,18 @@ class Controls(QWidget):
 
         self.thread.start()
 
-        def progress(x):
-            self.state["progress"] = x
-
-        def bump(x):
-            self.state["clicked"] += x * 0.5
-
         self.button.setEnabled(False)
         self.thread.finished.connect(lambda: self.button.setEnabled(True))
-        self.worker.result.connect(bump)
-        self.worker.progress.connect(progress)
+        self.worker.result.connect(self.on_result)
+        self.worker.progress.connect(self.on_progress)
+
+    @Slot(int)
+    def on_progress(self, x):
+        self.state["progress"] = x
+
+    @Slot(int)
+    def on_result(self, x):
+        self.state["clicked"] += x * 0.5
 
     def on_reset_clicked(self):
         self.state["clicked"] = 0
@@ -129,9 +130,6 @@ if __name__ == "__main__":
 
     app = QApplication([])
 
-    asyncio.set_event_loop_policy(QtAsyncio.QAsyncioEventLoopPolicy())
-    scheduler.register_asyncio()
-
     # Create layout and pass state to widgets
     layout = QVBoxLayout()
     layout.addWidget(Display(state))
@@ -142,4 +140,9 @@ if __name__ == "__main__":
     widget.show()
     widget.setWindowTitle("Clicked?")
 
-    app.exec()
+    init("asyncio")
+
+    # QtAsyncio.run() runs both the Qt and asyncio event loops together.
+    # The asyncio scheduler's flush handler calls get_event_loop() at
+    # flush time, so it will pick up QtAsyncio's loop.
+    QtAsyncio.run(keep_running=True, handle_sigint=True)

--- a/examples/observe_qt.py
+++ b/examples/observe_qt.py
@@ -143,4 +143,4 @@ if __name__ == "__main__":
     # QtAsyncio.run() runs both the Qt and asyncio event loops together.
     # The asyncio scheduler's flush handler calls get_event_loop() at
     # flush time, so it will pick up QtAsyncio's loop.
-    QtAsyncio.run(keep_running=True, handle_sigint=True)
+    QtAsyncio.run(handle_sigint=True)

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -50,7 +50,7 @@ class Scheduler:
 
     def request_flush_asyncio(self):
         loop = asyncio.get_event_loop()
-        loop.call_soon(self.flush)
+        loop.call_soon_threadsafe(self.flush)
 
     def register_asyncio(self):
         """

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -62,8 +62,8 @@ class Scheduler:
         """
         Legacy utility function for integration with Qt event loop. Note that using
         the `register_asyncio` method is preferred over this, together with
-        setting the asyncio event loop policy to `QtAsyncio.QAsyncioEventLoopPolicy`.
-        This is supported from Pyside 6.6.0. Note that the QtAsyncio submodule
+        running `QtAsyncio.run(...)` instead of app.exec().
+        This is supported from Pyside 6.7. Note that the QtAsyncio submodule
         is not included in the `pyside6_essentials` package.
         """
         for qt in ("PySide6", "PyQt6", "PySide2", "PyQt5", "PySide", "PyQt4"):
@@ -82,7 +82,7 @@ class Scheduler:
                 "QtAsyncio module available: please consider using `register_asyncio` "
                 "and call the following code:\n"
                 f"    from {qt} import QtAsyncio\n"
-                "    asyncio.set_event_loop_policy(QtAsyncio.QAsyncioEventLoopPolicy())"
+                "    QtAsyncio.run(handle_sigint=True)"
                 ""
             )
         except ImportError:
@@ -132,6 +132,7 @@ class Scheduler:
         self._queue_indices.clear()
         self.flushing = False
         self.has.clear()
+        self.waiting = False
         self.circular.clear()
         self.index = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 ]
 ruff = ["ruff"]
 qt = [
-    "PySide6>=6.6.2,!=6.8.3 ; python_version < '3.15'",
+    "PySide6>=6.7,!=6.8.3",
     "pytest-qt",
     "pytest-xvfb",
 ]

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -1,5 +1,3 @@
-import asyncio
-import warnings
 from weakref import ref
 
 import pytest
@@ -7,11 +5,7 @@ import pytest
 from observ import reactive, scheduler, watch
 
 try:
-    with warnings.catch_warnings():
-        # Filter deprecation warnings of event loop policies
-        # in Python 3.14, which will be removed in 3.16
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        from PySide6 import QtAsyncio, QtWidgets
+    from PySide6 import QtAsyncio, QtWidgets
 
     has_qt = True
 except ImportError:
@@ -21,20 +15,22 @@ qt_missing_reason = "Qt is not installed"
 
 @pytest.fixture
 def qtasyncio():
-    with warnings.catch_warnings():
-        # Filter deprecation warnings of event loop policies
-        # in Python 3.14, which will be removed in 3.16
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        old_policy = asyncio.get_event_loop_policy()
-        qt_policy = QtAsyncio.QAsyncioEventLoopPolicy(quit_qapp=False)
-        asyncio.set_event_loop_policy(qt_policy)
-        old_callback = scheduler.request_flush
-        scheduler.register_asyncio()
-        try:
-            yield
-        finally:
-            asyncio.set_event_loop_policy(old_policy)
-            scheduler.register_request_flush(old_callback)
+    # Normally when using observ in a Qt context, there would
+    # be a place to call QtAsyncio.run(...) to start the main
+    # loop. And if the scheduler is configured to run with
+    # asyncio, then it will pick up on Qt's asyncio main loop
+    # automatically. However, within pytest context, we can't
+    # do that, so instead, we create a new event loop explicitly
+    def schedule_qtasyncio_loop():
+        loop = QtAsyncio.asyncio.new_event_loop()
+        loop.call_soon_threadsafe(scheduler.flush)
+
+    old_callback = scheduler.request_flush
+    scheduler.register_request_flush(schedule_qtasyncio_loop)
+    try:
+        yield
+    finally:
+        scheduler.register_request_flush(old_callback)
 
 
 @pytest.mark.skipif(not has_qt, reason=qt_missing_reason)
@@ -65,7 +61,7 @@ def test_scheduler_pyside_asyncio(qtasyncio, qapp):
 
 
 @pytest.mark.skipif(not has_qt, reason=qt_missing_reason)
-def test_qt_integration(qapp):
+def test_qt_integration(qapp, qtasyncio):
     class Label(QtWidgets.QLabel):
         count = 0
 
@@ -95,6 +91,8 @@ def test_qt_integration(qapp):
 
     state = reactive({"count": 0})
     label = Label(state)
+
+    watcher = watch(lambda: state['count'], lambda x: x)
 
     state["count"] += 1
 

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -92,7 +92,7 @@ def test_qt_integration(qapp, qtasyncio):
     state = reactive({"count": 0})
     label = Label(state)
 
-    watcher = watch(lambda: state['count'], lambda x: x)
+    _watcher = watch(lambda: state["count"], lambda x: x)
 
     state["count"] += 1
 


### PR DESCRIPTION
Apparently, calling anonymous functions / closures as slots from within a QThread does not work well. When the callbacks were changed to be class methods, then the progress bar got displayed nicely again. I did notice that the callback got called properly, but it seems that it just doesn't trigger any change.

I'm opening this as draft, want to see if I can better understand this before closing it.