### PR TITLE
Fix deepcopy of Proxy objects creating unregistered zombie proxies

### DIFF
--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import copy, deepcopy
 from functools import partial
 from typing import Generic, Literal, TypedDict, TypeVar, cast
 
@@ -30,6 +31,12 @@ class Proxy(Generic[T]):
         self.__readonly__ = readonly
         self.__shallow__ = shallow
         proxy_db.reference(self)
+
+    def __copy__(self) -> T:
+        return copy(self.__target__)
+
+    def __deepcopy__(self, memo: dict) -> T:
+        return deepcopy(self.__target__, memo)
 
     def __del__(self):
         proxy_db.dereference(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "observ"
-version = "0.17.4"
+version = "0.18.0"
 description = "Reactive state management for Python"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -43,8 +43,10 @@ EXCLUDED = {
     "__reduce_ex__",
     "__hash__",
     "__class_getitem__",
-    # __del__ is custom method on Proxy
+    # __del__, __copy__, __deepcopy__ are custom methods on Proxy
     "__del__",
+    "__copy__",
+    "__deepcopy__",
     "__getstate__",
     # custom method on DictProxyBase
     "_orphaned_keydeps",

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -1,0 +1,51 @@
+"""Tests for copy/deepcopy behavior of Proxy objects."""
+
+import copy
+
+import pytest
+
+from observ import reactive
+from observ.proxy import Proxy
+
+
+@pytest.mark.parametrize(
+    "value, expected_type",
+    [
+        ({"a": 1, "b": 2}, dict),
+        ([1, 2, 3], list),
+        ({1, 2, 3}, set),
+    ],
+)
+def test_deepcopy_reactive_returns_plain_type(value, expected_type):
+    data = reactive(value)
+    result = copy.deepcopy(data)
+    assert type(result) is expected_type
+    assert not isinstance(result, Proxy)
+    assert result == value
+
+
+def test_deepcopy_is_independent():
+    data = reactive({"a": [1, 2]})
+    result = copy.deepcopy(data)
+    result["a"].append(3)
+    data["a"].pop()
+    assert data["a"] == [1]
+
+
+def test_copy_reactive_dict_returns_plain_dict():
+    data = reactive({"a": 1})
+    result = copy.copy(data)
+    assert type(result) is dict
+    assert not isinstance(result, Proxy)
+    assert result == {"a": 1}
+
+
+def test_deepcopy_nested_proxies_returns_plain_data():
+    data = reactive({"nested": {"inner": [1, 2, 3]}})
+    # Access nested to ensure they become proxies
+    inner = data["nested"]["inner"]
+    assert isinstance(inner, Proxy)
+    result = copy.deepcopy(data)
+    assert type(result) is dict
+    assert type(result["nested"]) is dict
+    assert type(result["nested"]["inner"]) is list


### PR DESCRIPTION
When `copy.deepcopy()` is called on an `observ` Proxy, Python's default deepcopy copies the slots without calling `__init__`. This means `proxy_db.reference()` is never called, producing a "zombie proxy" whose target is unknown to `proxy_db`. Any subsequent access raises `KeyError` in `proxy_db.attrs()`.

This surfaces when `reliev/patchdiff` call `deepcopy` on patch values that are Proxy objects during undo/redo.

This would also make some code in `patchdiff` a bit simpler, by just being able to call `deepcopy` on the state that it operates on.