### PR TITLE
Add performance benchmarks for hot paths

### DIFF
--- a/bench/test_creation.py
+++ b/bench/test_creation.py
@@ -1,0 +1,46 @@
+"""
+Benchmarks for the cost of creating proxies and watchers.
+
+Creating a proxy for a dict registers the target in the proxy_db and
+eagerly creates a Dep for every key, so proxy creation cost scales
+with the number of keys.
+"""
+
+import gc
+
+import pytest
+
+from observ import reactive, watch
+
+SIZES = [10, 1_000, 100_000]
+SIZE_IDS = ["10", "1k", "100k"]
+
+
+def noop():
+    pass
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="proxy_creation_dict")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_proxy_creation_dict(benchmark, size):
+    def setup():
+        # Collect garbage in between rounds (outside of the measured
+        # code) so that proxy_db entries for the previous rounds are
+        # cleaned up deterministically instead of adding gc noise to
+        # the measurement
+        gc.collect()
+        return ({f"key_{i}": i for i in range(size)},), {}
+
+    benchmark.pedantic(reactive, setup=setup, warmup_rounds=1, rounds=30)
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="watcher_creation")
+def test_watcher_creation(benchmark):
+    state = reactive({"count": 0})
+
+    def create_watcher():
+        return watch(lambda: state["count"], callback=noop, sync=True)
+
+    benchmark(create_watcher)

--- a/bench/test_deep_watch.py
+++ b/bench/test_deep_watch.py
@@ -1,0 +1,34 @@
+"""
+End-to-end benchmarks for the common hot path of a deep watcher:
+mutating a single leaf in a large watched tree, which notifies the
+watcher, re-evaluates the watched expression and re-traverses the
+whole structure to keep tracking all nested dependencies.
+"""
+
+import pytest
+
+from observ import reactive, watch
+
+
+def noop():
+    pass
+
+
+def make_tree(n_branches):
+    return {
+        f"branch_{i}": {"leaves": list(range(10)), "flag": 0} for i in range(n_branches)
+    }
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="deep_watch_mutate_leaf")
+@pytest.mark.parametrize("n_branches", [10, 100, 1_000], ids=["10", "100", "1k"])
+def test_deep_watch_mutate_leaf(benchmark, n_branches):
+    state = reactive(make_tree(n_branches))
+    watcher = watch(state, callback=noop, deep=True, sync=True)  # noqa: F841
+
+    def mutate():
+        state["branch_0"]["flag"] = 1
+        state["branch_0"]["flag"] = 0
+
+    benchmark(mutate)

--- a/bench/test_notify.py
+++ b/bench/test_notify.py
@@ -1,0 +1,31 @@
+"""
+Benchmarks for notifying watchers subscribed to the same piece of
+reactive state. Dep.notify sorts its subscribers on every notification,
+so these benchmarks guard how notification cost scales with the number
+of subscribed watchers.
+"""
+
+import pytest
+
+from observ import reactive, watch
+
+
+def noop():
+    pass
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="notify_watchers")
+@pytest.mark.parametrize("n_watchers", [10, 100, 1_000], ids=["10", "100", "1k"])
+def test_notify_watchers(benchmark, n_watchers):
+    state = reactive({"count": 0})
+    watchers = [  # noqa: F841
+        watch(lambda: state["count"], callback=noop, sync=True)
+        for _ in range(n_watchers)
+    ]
+
+    def mutate():
+        state["count"] = 1
+        state["count"] = 0
+
+    benchmark(mutate)

--- a/bench/test_reads.py
+++ b/bench/test_reads.py
@@ -1,0 +1,100 @@
+"""
+Benchmarks for read operations on reactive datastructures.
+
+Every read through a proxy runs the returned value through the full
+`proxy()` machinery, even when the value is a plain (unproxyable)
+value like an int or str. These benchmarks measure that read overhead,
+compared against plain datastructures, both outside of a watcher
+(untracked) and during a watcher evaluation (tracked).
+
+Each benchmarked function performs a batch of 100 reads (or a full
+iteration) so that the measured times are well above timer resolution.
+"""
+
+from functools import partial
+
+import pytest
+
+from observ import reactive
+from observ.watcher import Watcher
+
+SIZE = 1_000
+KEYS = [f"key_{i}" for i in range(0, SIZE, 10)]
+INDICES = list(range(0, SIZE, 10))
+
+
+def make_dict():
+    return {f"key_{i}": i for i in range(SIZE)}
+
+
+def read_dict_keys(obj):
+    for key in KEYS:
+        _ = obj[key]
+
+
+def read_list_items(obj):
+    for index in INDICES:
+        _ = obj[index]
+
+
+def iterate_dict_values(obj):
+    for _value in obj.values():
+        pass
+
+
+def iterate_list(obj):
+    for _item in obj:
+        pass
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="read_dict_getitem")
+@pytest.mark.parametrize("kind", ["plain", "reactive"])
+def test_read_dict_getitem(benchmark, kind):
+    obj = make_dict()
+    if kind == "reactive":
+        obj = reactive(obj)
+    benchmark(partial(read_dict_keys, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="read_list_getitem")
+@pytest.mark.parametrize("kind", ["plain", "reactive"])
+def test_read_list_getitem(benchmark, kind):
+    obj = list(range(SIZE))
+    if kind == "reactive":
+        obj = reactive(obj)
+    benchmark(partial(read_list_items, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="read_dict_iterate_values")
+@pytest.mark.parametrize("kind", ["plain", "reactive"])
+def test_read_dict_iterate_values(benchmark, kind):
+    obj = make_dict()
+    if kind == "reactive":
+        obj = reactive(obj)
+    benchmark(partial(iterate_dict_values, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="read_list_iterate")
+@pytest.mark.parametrize("kind", ["plain", "reactive"])
+def test_read_list_iterate(benchmark, kind):
+    obj = list(range(SIZE))
+    if kind == "reactive":
+        obj = reactive(obj)
+    benchmark(partial(iterate_list, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="read_tracked")
+def test_read_dict_getitem_tracked(benchmark):
+    """
+    Benchmark reads during a watcher evaluation, so with dependency
+    tracking active. This includes the cost of registering the deps
+    on the watcher and the dep cleanup afterwards.
+    """
+    obj = reactive(make_dict())
+    watcher = Watcher(partial(read_dict_keys, obj), deep=False)
+    benchmark(watcher.get)

--- a/bench/test_writes.py
+++ b/bench/test_writes.py
@@ -1,0 +1,100 @@
+"""
+Benchmarks for write operations on reactive datastructures at
+different container sizes.
+
+The write traps currently copy the whole container in order to detect
+changes, which makes writes O(n) in the size of the container. These
+benchmarks guard how the cost of a single write operation scales with
+container size.
+
+Each benchmarked function performs a pair of operations that leaves the
+container in its original state, so that the container size stays
+constant across benchmark rounds.
+"""
+
+from functools import partial
+
+import pytest
+
+from observ import reactive
+
+SIZES = [10, 1_000, 100_000]
+SIZE_IDS = ["10", "1k", "100k"]
+
+
+def bench_list_append(obj):
+    obj.append(None)
+    obj.pop()
+
+
+def bench_list_setitem(obj):
+    obj[0] = 1
+    obj[0] = 0
+
+
+def bench_dict_setitem(obj):
+    obj["key_0"] = 1
+    obj["key_0"] = 0
+
+
+def bench_dict_new_key(obj):
+    obj["new_key"] = 0
+    del obj["new_key"]
+
+
+def bench_dict_update(obj):
+    obj.update({"key_0": 1})
+    obj.update({"key_0": 0})
+
+
+def bench_set_add(obj):
+    obj.add("x")
+    obj.discard("x")
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_list_append")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_list_append(benchmark, size):
+    obj = reactive(list(range(size)))
+    benchmark(partial(bench_list_append, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_list_setitem")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_list_setitem(benchmark, size):
+    obj = reactive(list(range(size)))
+    benchmark(partial(bench_list_setitem, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_dict_setitem")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_dict_setitem(benchmark, size):
+    obj = reactive({f"key_{i}": i for i in range(size)})
+    benchmark(partial(bench_dict_setitem, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_dict_new_key")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_dict_new_key(benchmark, size):
+    obj = reactive({f"key_{i}": i for i in range(size)})
+    benchmark(partial(bench_dict_new_key, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_dict_update")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_dict_update(benchmark, size):
+    obj = reactive({f"key_{i}": i for i in range(size)})
+    benchmark(partial(bench_dict_update, obj))
+
+
+@pytest.mark.timeout(timeout=0)
+@pytest.mark.benchmark(group="write_set_add")
+@pytest.mark.parametrize("size", SIZES, ids=SIZE_IDS)
+def test_write_set_add(benchmark, size):
+    obj = reactive(set(range(size)))
+    benchmark(partial(bench_set_add, obj))


### PR DESCRIPTION
Extends the benchmark suite ahead of a series of planned performance improvements, so each upcoming PR can be validated by the benchmark CI comparison against master.

## New benchmarks

| File | Group(s) | What it guards |
|------|----------|----------------|
| `bench/test_writes.py` | `write_*` | Write ops parametrized over container size (10/1k/100k). The write traps copy the whole container for change detection, so writes are currently O(n): `list.append` goes from 0.7 µs (10 elems) to ~420 µs (100k), `dict.update` from 1.7 µs to ~10 ms. `dict.__setitem__` (key-writer path, no copy) stays flat as contrast. |
| `bench/test_reads.py` | `read_*` | Read overhead vs plain datastructures (currently ~30–160x), untracked and tracked (during watcher evaluation). Every read runs its result through the full `proxy()` machinery, even plain values. |
| `bench/test_deep_watch.py` | `deep_watch_mutate_leaf` | End-to-end hot path: mutating one leaf of a large deep-watched tree (notify → re-evaluate → traverse). Scales with tree size: 0.35 ms at 10 branches → 36 ms at 1k branches. |
| `bench/test_creation.py` | `proxy_creation_dict`, `watcher_creation` | Proxy creation eagerly allocates a Dep per dict key (~20 ms for 100k keys); watcher creation cost. |
| `bench/test_notify.py` | `notify_watchers` | Notification cost over subscriber count (`Dep.notify` sorts subscribers on every notification). |

Write benchmarks use self-reversing operation pairs so container size stays constant across rounds. Numbers above are from a local run (macOS, Python per `.python-version`).

## Planned follow-up PRs

1. Fast-path plain values in `proxy()` (read path)
2. Type-keyed `TYPE_LOOKUP` instead of predicate iteration
3. Per-method change detection in `write_trap` instead of copy-and-diff
4. `traverse` over raw targets instead of proxy iterators
5. Assorted trap/dep micro-optimizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)