### PR TITLE
Fast-path plain values in proxy()

### DIFF
--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -46,6 +46,11 @@ class Proxy(Generic[T]):
 # that will convert an object of that type to a proxied version
 TYPE_LOOKUP = {}
 
+# Types of values that can't be proxied. Note the exact type is
+# checked (no subclasses) so that these can be ruled out with a
+# single set containment check
+PLAIN_TYPES = frozenset({type(None), bool, int, float, str, bytes})
+
 
 def proxy(target: T, readonly=False, shallow=False) -> T:
     """
@@ -56,6 +61,12 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
     Please be aware: this only works on plain data types: dict, list,
     set and tuple!
     """
+    # Plain values can't be proxied, so return them as-is. This is the
+    # most common case since this function is called on the result of
+    # every read from a proxied container, so it is checked first
+    if type(target) in PLAIN_TYPES:
+        return target
+
     # The object may be a proxy already, so check if it matches the
     # given configuration (readonly and shallow)
     if isinstance(target, Proxy):


### PR DESCRIPTION
First of the planned performance improvements following #166.

`proxy()` is called on the result of every read from a proxied container — including scalar results like ints and strs. For those it would run an `isinstance(Proxy)` check, a proxy_db lookup and all three `TYPE_LOOKUP` predicate calls before concluding the value can't be proxied. Profiling showed this accounted for ~80% of the cost of a scalar read through a proxy.

This adds an early return for plain immutable types (`NoneType`, `bool`, `int`, `float`, `str`, `bytes`) using a single frozenset containment check on the exact type. Subclasses intentionally don't match the exact-type check and continue through the regular (unchanged) path, so behavior is identical for anything that isn't exactly one of these types.

## Benchmark results (mean, local run, vs master)

| Benchmark | master | this PR | change |
|---|---|---|---|
| `read_dict_getitem[reactive]` | 67.1 µs | 24.5 µs | −64% |
| `read_list_getitem[reactive]` | 65.1 µs | 23.1 µs | −65% |
| `read_dict_iterate_values[reactive]` | 567 µs | 148 µs | −74% |
| `read_list_iterate[reactive]` | 569 µs | 148 µs | −74% |
| `read_tracked` | 139 µs | 95 µs | −32% |
| `deep_watch_mutate_leaf[1k]` | 35.8 ms | 24.1 ms | −33% |

The deep-watch improvement comes from `traverse` running every visited value through `proxy()` via the iterator traps.

Full test suite passes (163 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)