### PR TITLE
Key TYPE_LOOKUP on type instead of predicate functions

### DIFF
--- a/observ/dict_proxy.py
+++ b/observ/dict_proxy.py
@@ -82,8 +82,4 @@ ReadonlyDictProxy = type(
 )
 
 
-def type_test(target):
-    return type(target) is dict
-
-
-TYPE_LOOKUP[type_test] = (DictProxy, ReadonlyDictProxy)
+TYPE_LOOKUP[dict] = (DictProxy, ReadonlyDictProxy)

--- a/observ/list_proxy.py
+++ b/observ/list_proxy.py
@@ -73,8 +73,4 @@ ReadonlyListProxy = type(
 )
 
 
-def type_test(target):
-    return type(target) is list
-
-
-TYPE_LOOKUP[type_test] = (ListProxy, ReadonlyListProxy)
+TYPE_LOOKUP[list] = (ListProxy, ReadonlyListProxy)

--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -42,8 +42,9 @@ class Proxy(Generic[T]):
         proxy_db.dereference(self)
 
 
-# Lookup dict for mapping a type (dict, list, set) to a method
-# that will convert an object of that type to a proxied version
+# Lookup dict for mapping a type (dict, list, set) to a tuple
+# of proxy types (writable, readonly) for that type. Keyed on the
+# exact type, so subclasses are (deliberately) not proxied
 TYPE_LOOKUP = {}
 
 
@@ -75,10 +76,10 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
         return existing_proxy
 
     # Create a new proxy
-    for type_test, (writable_proxy_type, readonly_proxy_type) in TYPE_LOOKUP.items():
-        if type_test(target):
-            proxy_type = readonly_proxy_type if readonly else writable_proxy_type
-            return proxy_type(target, readonly=readonly, shallow=shallow)
+    proxy_types = TYPE_LOOKUP.get(type(target))
+    if proxy_types is not None:
+        proxy_type = proxy_types[1] if readonly else proxy_types[0]
+        return proxy_type(target, readonly=readonly, shallow=shallow)
 
     if isinstance(target, tuple):
         return cast(

--- a/observ/set_proxy.py
+++ b/observ/set_proxy.py
@@ -79,8 +79,4 @@ ReadonlySetProxy = type(
 )
 
 
-def type_test(target):
-    return type(target) is set
-
-
-TYPE_LOOKUP[type_test] = (SetProxy, ReadonlySetProxy)
+TYPE_LOOKUP[set] = (SetProxy, ReadonlySetProxy)


### PR DESCRIPTION
Part of the performance series following #166; independent of #167 (touches the same file in a different region, so whichever merges second may need a trivial rebase).

`proxy()` located the proxy type by iterating `TYPE_LOOKUP` and calling each registered predicate. All three registered predicates were `type(target) is X`, so this replaces the predicate iteration with a single dict lookup keyed on `type(target)`. Exact-type matching semantics are unchanged — subclasses of dict/list/set are still not proxied.

## Benchmark results (mean, local run, vs master)

| Benchmark | master | this PR | change |
|---|---|---|---|
| `read_dict_getitem[reactive]` | 67.1 µs | 50.1 µs | −25% |
| `read_dict_iterate_values[reactive]` | 567 µs | 397 µs | −30% |
| `read_list_iterate[reactive]` | 569 µs | 390 µs | −31% |

Note: overlaps in effect with #167 — once the plain-value fast path is in, most `proxy()` calls never reach `TYPE_LOOKUP`, so the combined win is smaller than the sum. This change still helps every container-valued read and proxy creation.

Full test suite passes (163 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)