### PR TITLE
Use per-method change detection in write traps

### DIFF
--- a/observ/traps.py
+++ b/observ/traps.py
@@ -70,30 +70,121 @@ def read_key_trap(method, obj_cls):
     return trap
 
 
+# Sentinel to distinguish 'key not present' from 'value is None'
+_MISSING = object()
+
+
 def write_trap(method, obj_cls):
+    """
+    Returns a trap with the cheapest change detection strategy that
+    is correct for the given method, so that writes don't need a copy
+    of the whole container to detect changes.
+    """
+    if obj_cls is dict:
+        # update and __ior__: only the incoming keys can change
+        return write_dict_trap(method, obj_cls)
+    if method in ("sort", "reverse", "symmetric_difference_update"):
+        # These methods can change the container without changing its
+        # length, so fall back to copy-and-compare. The cost of the
+        # copy is proportional to the operation itself
+        return write_copy_compare_trap(method, obj_cls)
+    if method == "__setitem__":
+        # list only: compare just the affected index or slice
+        return write_setitem_trap(method, obj_cls)
+    # The remaining list and set methods can only change the container
+    # by changing its length
+    return write_len_compare_trap(method, obj_cls)
+
+
+def write_dict_trap(method, obj_cls):
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
     def trap(self, *args, **kwargs):
-        old = self.__target__.copy()
-        retval = fn(self.__target__, *args, **kwargs)
+        target = self.__target__
+        # Normalize the arguments (an optional mapping or iterable of
+        # key/value pairs, plus optional keyword arguments) into a
+        # single dict, so that only the incoming keys have to be
+        # diffed for changes. This also makes sure that an iterable
+        # argument is not consumed twice
+        if args:
+            incoming = dict(args[0])
+            if kwargs:
+                incoming.update(kwargs)
+        else:
+            incoming = kwargs
+        old_values = {key: target.get(key, _MISSING) for key in incoming}
+        retval = fn(target, incoming)
         attrs = proxy_db.attrs(self)
-        if obj_cls is dict:
-            change_detected = False
-            keydeps = attrs["keydep"]
-            for key, val in self.__target__.items():
-                if old.get(key) is not val:
-                    if key in keydeps:
-                        keydeps[key].notify()
-                    else:
-                        keydeps[key] = Dep()
-                    change_detected = True
-            if change_detected:
-                attrs["dep"].notify()
-        else:  # list and set
-            if self.__target__ != old:
-                attrs["dep"].notify()
+        keydeps = attrs["keydep"]
+        change_detected = False
+        for key, old_value in old_values.items():
+            if old_value is not target.get(key, _MISSING):
+                if key in keydeps:
+                    keydeps[key].notify()
+                else:
+                    keydeps[key] = Dep()
+                change_detected = True
+        if change_detected:
+            attrs["dep"].notify()
+        return retval
 
+    return trap
+
+
+def write_len_compare_trap(method, obj_cls):
+    fn = getattr(obj_cls, method)
+
+    @wraps(fn)
+    def trap(self, *args, **kwargs):
+        target = self.__target__
+        old_len = len(target)
+        retval = fn(target, *args, **kwargs)
+        if len(target) != old_len:
+            proxy_db.attrs(self)["dep"].notify()
+        return retval
+
+    return trap
+
+
+def write_copy_compare_trap(method, obj_cls):
+    fn = getattr(obj_cls, method)
+
+    @wraps(fn)
+    def trap(self, *args, **kwargs):
+        target = self.__target__
+        old = target.copy()
+        retval = fn(target, *args, **kwargs)
+        if target != old:
+            proxy_db.attrs(self)["dep"].notify()
+        return retval
+
+    return trap
+
+
+def write_setitem_trap(method, obj_cls):
+    fn = getattr(obj_cls, method)
+
+    @wraps(fn)
+    def trap(self, key, value):
+        target = self.__target__
+        try:
+            old_value = target[key]
+        except (IndexError, TypeError):
+            # Let the actual operation raise the appropriate error
+            return fn(target, key, value)
+        if type(key) is slice:
+            # Slice assignment can change the length as well as
+            # replace a same-length stretch of items
+            old_len = len(target)
+            retval = fn(target, key, value)
+            changed = len(target) != old_len or target[key] != old_value
+        else:
+            retval = fn(target, key, value)
+            new_value = target[key]
+            changed = new_value is not old_value and new_value != old_value
+        if changed:
+            proxy_db.attrs(self)["dep"].notify()
         return retval
 
     return trap

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -422,11 +422,47 @@ def test_dict_update_new_keys():
     assert state["baz"] == "fool"
     assert called == 3
 
+
+def test_dict_update_new_key_with_none_value():
+    state = reactive({})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: len(state), _expr, sync=True, deep=True)
+
+    state.update({"foo": None})
+
+    assert state["foo"] is None
+    assert called == 1
+
+
+def test_dict_update_with_iterable_of_pairs():
+    state = reactive({"foo": "bar"})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: len(state), _expr, sync=True, deep=True)
+
+    state.update((key, value) for key, value in [("fizz", "buzz"), ("baz", "fool")])
+
+    assert state["fizz"] == "buzz"
+    assert state["baz"] == "fool"
+    assert state["foo"] == "bar"
+    assert called == 1
+
     state.update([("foo", "bas"), ("bat", "flat")])
 
     assert state["foo"] == "bas"
     assert state["bat"] == "flat"
-    assert called == 4
+    # The dict's dep is notified once per update() call
+    # (the per-key deps are notified separately)
+    assert called == 2
 
 
 def test_list_iter():


### PR DESCRIPTION
Part of the performance series following #166. Independent of #167/#168 (no file overlap).

Every write through a `WRITERS` trap copied the whole container and diffed it against the result, making all writes O(n) in container size. This replaces the single copy-and-diff trap with the cheapest correct strategy per method, chosen at trap construction time:

| Methods | Strategy |
|---|---|
| dict `update`, `__ior__` | Diff only the incoming keys (sentinel distinguishes missing keys from `None` values). The argument is normalized to a dict first, which also means one-shot iterables of pairs are not consumed twice. |
| list/set methods that can only change the container by changing its length (`append`, `insert`, `extend`, `pop`, `remove`, `add`, `discard`, `clear`, `update`, `difference_update`, `intersection_update`, `__delitem__`, `__iadd__`, `__imul__`) | Length compare before/after |
| list `__setitem__` | Compare only the affected index or slice (plus length for slice assignment) |
| `sort`, `reverse`, `symmetric_difference_update` | Keep copy-and-compare: they can change content without changing length, and the copy cost is proportional to the operation itself, so no false-positive notifications are introduced |

## Behavior fix (with regression test)

Adding a new key with value `None` via `update()` previously did not notify, because the old diff used `old.get(key)`, which conflates "key was missing" with "value was None". The new sentinel-based diff detects this correctly.

## Benchmark results (mean, local run, vs master)

| Benchmark | master | this PR |
|---|---|---|
| `write_list_append[100k]` | 423 µs | 0.58 µs |
| `write_list_setitem[100k]` | 423 µs | 0.54 µs |
| `write_dict_update[100k]` | 9.7 ms | 1.5 µs |
| `write_set_add[100k]` | 1.15 ms | 0.63 µs |
| `write_dict_setitem` / `write_dict_new_key` (key-writer path, untouched) | ~0.9 µs | ~0.9 µs |
| `*_plain_vs_reactive` (small containers) | — | unchanged within noise |

Full test suite passes (165 passed, 1 xfailed), including two new tests for dict `update()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)