### PR TITLE
Traverse raw targets instead of proxy iterators

### DIFF
--- a/observ/__init__.py
+++ b/observ/__init__.py
@@ -3,6 +3,8 @@ from importlib.metadata import version
 __version__ = version("observ")
 
 
+# Importing the proxy modules registers their types in TYPE_LOOKUP
+from . import dict_proxy, list_proxy, set_proxy
 from .init import init, loop_factory
 from .proxy import (
     reactive,

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -16,10 +16,9 @@ from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from weakref import WeakSet, ref
 
 from .dep import Dep
-from .dict_proxy import DictProxyBase
-from .list_proxy import ListProxyBase
+from .proxy import Proxy, proxy
+from .proxy_db import proxy_db
 from .scheduler import scheduler
-from .set_proxy import SetProxyBase
 
 T = TypeVar("T")
 Watchable = Union[
@@ -76,32 +75,55 @@ def computed(_fn: Callable[[], T] | None = None, *, deep=True) -> Callable[[], T
 
 def traverse(obj):
     """
-    Non-recursively traverse the whole tree to make sure that all values have been 'get'
+    Non-recursively traverse the whole tree to make sure that the dep of
+    every (nested) container has been depended on.
 
-    Track which objects we have already seen to support(!) full traversal of data
-    structures with cycles.
-    A set is used to provide faster containment checks and a list is used to make
-    sure that ids are not being reused for the duration of this method.
-    The traversed objects are not hashable (except for tuple) because they are mutable.
-    Converting everything to a hashable thing (because nothing is mutated during
-    traversal) is an option but way more expensive than just using a list + set.
+    Instead of iterating through the proxies' trapped iterators (which
+    would create a proxy for every visited value), this walks the raw
+    targets and registers a dependency on the dep of each container
+    directly. That is equivalent: all mutation traps notify the dep of
+    the container that they mutate. Containers that don't have an entry
+    in the proxy_db yet (raw values nested inside a proxied target) are
+    registered along the way, so that mutations through (future) proxies
+    for those containers will be seen.
+
+    Every item on the stack is accompanied by a 'tracked' flag, which
+    marks containers that are reachable through non-shallow proxies.
+    Raw containers that are not reachable through a proxy are not
+    tracked (there is no proxy through which they can be mutated), and
+    neither are children of shallow proxies (matching the shallow
+    iterators, which yield raw values) — unless a child is itself a
+    proxy, which always tracks its own dep.
+
+    Track which objects we have already seen (by id) to support(!) full
+    traversal of data structures with cycles. Since only raw targets are
+    traversed, every seen object is kept alive through the (unchanging)
+    tree that is being traversed, so ids can't be reused for the
+    duration of this method.
     """
-    seen = []
     seen_ids = set()
-    stack = deque([obj])
+    stack = deque([(obj, False)])
+    db = proxy_db.db
+    track = bool(Dep.stack)
 
     while stack:
-        current = stack.pop()
+        current, tracked = stack.pop()
+
+        if isinstance(current, Proxy):
+            # A proxy always tracks its own dep; whether its children
+            # are tracked depends on the shallow flag
+            tracked = True
+            child_tracked = not current.__shallow__
+            current = current.__target__
+        else:
+            child_tracked = tracked
 
         # We are only interested in traversing a fixed set of types
         # otherwise we can just continue with the next branch
-        if isinstance(current, (dict, DictProxyBase)):
-            if not current:
-                continue
+        cls = type(current)
+        if cls is dict:
             val_iter = current.values()
-        elif isinstance(current, (list, ListProxyBase, set, SetProxyBase, tuple)):
-            if not current:
-                continue
+        elif cls is list or cls is set or cls is tuple:
             val_iter = current
         else:
             continue
@@ -112,11 +134,22 @@ def traverse(obj):
             continue
 
         # Mark as seen
-        seen.append(current)
         seen_ids.add(obj_id)
 
+        # Depend on the container's dep (tuples are immutable
+        # and have no dep)
+        if track and tracked and cls is not tuple:
+            entry = db.get(obj_id)
+            if entry is None:
+                # Materialize the container in the proxy_db
+                # so that it gets a dep to subscribe to
+                proxy(current)
+                entry = db[obj_id]
+            entry["attrs"]["dep"].depend()
+
         # Add children to stack
-        stack.extend(val_iter)
+        if current:
+            stack.extend((value, child_tracked) for value in val_iter)
 
 
 # Every Watcher gets a unique ID which is used to

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -313,3 +313,24 @@ def test_proxy_is_slotted():
         AttributeError, match="'SetProxy' object has no attribute 'foo'"
     ):
         some_set.foo = "foo"
+
+
+def test_proxy_types_registered_without_extra_imports():
+    """
+    Importing just the top-level package must be enough to register
+    the proxy types in TYPE_LOOKUP. Run in a fresh interpreter, since
+    within the test suite the proxy modules are already imported
+    directly by (other) test modules, which would mask a missing
+    registration.
+    """
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from observ import reactive; assert type(reactive({})) is not dict",
+        ],
+        check=True,
+    )


### PR DESCRIPTION
Part of the performance series following #166. Independent of #167/#168/#169 (different code regions; #167/#168 touch `proxy.py` which this PR only imports).

Deep watchers re-run `traverse` on every evaluation, and traversing through the proxies' trapped iterators created a generator plus a child proxy for **every visited value**, every time. This was the dominant cost of deep watching.

## Approach

`traverse` now walks the raw targets and registers a dependency on each container's `dep` directly. This is equivalent to the old behavior: every mutation trap notifies the dep of the container it mutates (key writes notify both the keydep and the container dep). Raw containers nested inside proxied targets are registered in the proxy_db along the way — the old implementation did the same implicitly by proxying them during iteration — so mutations through (future) proxy paths keep notifying the watcher.

A `tracked` flag on the traversal stack preserves the existing semantics exactly:
- children of **shallow** proxies are not tracked (matching shallow iterators, which yield raw values),
- raw containers not reachable through any proxy are not tracked (there is no proxy through which they can be mutated),
- proxies encountered anywhere always track their own dep.

Verified behavior parity for: nested never-read containers, containers added after the watch, shallow proxies, cyclic structures, and proxies inside raw containers.

## Bug surfaced along the way

The dict/list/set proxy types were registered in `TYPE_LOOKUP` as a side effect of `watcher.py`'s imports — with those imports removed, `reactive({})` returned a plain dict in a fresh interpreter. The top-level package now imports the proxy modules explicitly, with a fresh-interpreter regression test (inside the test suite this is masked, because other test modules import the proxy modules directly).

## Benchmark results (mean, local run, vs master)

| Benchmark | master | this PR | speedup |
|---|---|---|---|
| `traverse_deep` | 363 µs | 46 µs | 7.9x |
| `traverse_wide` | 4.28 ms | 0.51 ms | 8.3x |
| `traverse_mixed` | 211 µs | 27 µs | 7.7x |
| `traverse_matrix` | 1.98 ms | 0.27 ms | 7.3x |
| `traverse_stress_large_shallow` | 727 µs | 105 µs | 6.9x |
| `deep_watch_mutate_leaf[10]` | 347 µs | 74 µs | 4.7x |
| `deep_watch_mutate_leaf[1k]` | 35.8 ms | 6.8 ms | 5.3x |

(The standalone `traverse_*` benchmarks run outside a watcher and so skip dep registration entirely; the `deep_watch_mutate_leaf` numbers show the full in-watcher path.)

Full test suite passes (164 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)