### PR TITLE
Create keydeps lazily plus assorted trap/dep micro-optimizations

### DIFF
--- a/observ/dep.py
+++ b/observ/dep.py
@@ -5,8 +5,11 @@ are attached to observable datastructures.
 
 from __future__ import annotations
 
+from operator import attrgetter
 from typing import ClassVar
 from weakref import WeakSet
+
+sub_id = attrgetter("id")
 
 
 class Dep:
@@ -36,5 +39,5 @@ class Dep:
         # because a weakset must acquire a lock on its
         # weak references before iterating
         if self._subs:
-            for sub in sorted(self._subs, key=lambda s: s.id):
+            for sub in sorted(self._subs, key=sub_id):
                 sub.update()

--- a/observ/proxy_db.py
+++ b/observ/proxy_db.py
@@ -75,19 +75,23 @@ class ProxyDb:
         target = proxy.__target__
         obj_id = id(target)
 
-        if obj_id not in self.db:
+        entry = self.db.get(obj_id)
+        if entry is None:
             attrs = {}
             if isinstance(target, dict):
                 attrs["dep"] = Dep()
-                attrs["keydep"] = {key: Dep() for key in target.keys()}
+                # keydeps are created lazily: when a key is read
+                # (with dependency tracking active) or written
+                attrs["keydep"] = {}
             elif isinstance(target, (list, set)):
                 attrs["dep"] = Dep()
-            self.db[obj_id] = {
+            entry = {
                 "target": target,
                 "attrs": attrs,  # dep, keydep
                 # keyed on tuple(readonly, shallow)
                 "proxies": WeakValueDictionary(),
             }
+            self.db[obj_id] = entry
 
         # Use setdefault to put the proxy in the proxies dict. If there
         # was an existing value, it will return that instead. There shouldn't
@@ -95,7 +99,7 @@ class ProxyDb:
         # should raise an exception.
         # Seems to be a tiny bit faster than checking beforehand if
         # there is already an existing value in the proxies dict
-        result = self.db[obj_id]["proxies"].setdefault(
+        result = entry["proxies"].setdefault(
             (proxy.__readonly__, proxy.__shallow__), proxy
         )
         if result is not proxy:
@@ -106,7 +110,8 @@ class ProxyDb:
         Removes a reference from the database for the given proxy
         """
         obj_id = id(proxy.__target__)
-        if obj_id not in self.db:
+        entry = self.db.get(obj_id)
+        if entry is None:
             # When there are failing tests, it might happen that proxies
             # are garbage collected at a point where the proxy_db is already
             # cleared. That's why we need this check here.
@@ -117,8 +122,8 @@ class ProxyDb:
         # The given proxy is the last proxy in the WeakValueDictionary,
         # so now is a good moment to see if can remove clean the deps
         # for the target object
-        if len(self.db[obj_id]["proxies"]) == 1:
-            ref_count = sys.getrefcount(self.db[obj_id]["target"])
+        if len(entry["proxies"]) == 1:
+            ref_count = sys.getrefcount(entry["target"])
             # Ref count is still 3 here because of the reference
             # through proxy.__target__
             if ref_count <= 3:

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -8,6 +8,9 @@ import importlib
 import warnings
 from bisect import bisect
 from collections import defaultdict
+from operator import attrgetter
+
+watcher_id = attrgetter("id")
 
 
 class Scheduler:
@@ -125,7 +128,7 @@ class Scheduler:
 
         self.flushing = True
         self.waiting = False
-        self._queue.sort(key=lambda s: s.id)
+        self._queue.sort(key=watcher_id)
         self._queue_indices.sort()
 
         while self.index < len(self._queue):

--- a/observ/traps.py
+++ b/observ/traps.py
@@ -31,6 +31,8 @@ def read_trap(method, obj_cls):
 
 def iterate_trap(method, obj_cls):
     fn = getattr(obj_cls, method)
+    # Hoist the method check out of the trap
+    is_items = method == "items"
 
     @wraps(fn)
     def trap(self, *args, **kwargs):
@@ -39,7 +41,7 @@ def iterate_trap(method, obj_cls):
         iterator = fn(self.__target__, *args, **kwargs)
         if self.__shallow__:
             return iterator
-        if method == "items":
+        if is_items:
             return (
                 (key, proxy(value, readonly=self.__readonly__))
                 for key, value in iterator
@@ -102,23 +104,26 @@ def write_trap(method, obj_cls):
 def write_key_trap(method, obj_cls):
     fn = getattr(obj_cls, method)
     getitem_fn = getattr(obj_cls, "get")
+    # Hoist the method check out of the trap
+    is_setdefault = method == "setdefault"
 
     @wraps(fn)
     def trap(self, *args, **kwargs):
+        target = self.__target__
         key = args[0]
-        attrs = proxy_db.attrs(self)
-        is_new = key not in attrs["keydep"]
-        old_value = getitem_fn(self.__target__, key) if not is_new else None
-        retval = fn(self.__target__, *args, **kwargs)
-        if method == "setdefault" and not self.__shallow__:
+        is_new = key not in target
+        old_value = getitem_fn(target, key) if not is_new else None
+        retval = fn(target, *args, **kwargs)
+        if is_setdefault and not self.__shallow__:
             # This method is only available when readonly is false
             retval = proxy(retval)
 
-        new_value = getitem_fn(self.__target__, key)
-        if is_new:
-            attrs["keydep"][key] = Dep()
+        new_value = getitem_fn(target, key)
         if xor(old_value is None, new_value is None) or old_value != new_value:
-            attrs["keydep"][key].notify()
+            attrs = proxy_db.attrs(self)
+            keydep = attrs["keydep"].get(key)
+            if keydep is not None:
+                keydep.notify()
             attrs["dep"].notify()
         return retval
 
@@ -151,7 +156,9 @@ def delete_key_trap(method, obj_cls):
         retval = fn(self.__target__, *args, **kwargs)
         if key_existed:
             attrs["dep"].notify()
-            attrs["keydep"][key].notify()
+            keydep = attrs["keydep"].get(key)
+            if keydep is not None:
+                keydep.notify()
         return retval
 
     return trap

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -226,8 +226,11 @@ def test_dict_notify():
         coll = DictProxy({2: 3})
         old_keys = set(coll.keys())
         proxy_db.attrs(coll)["dep"].add_sub(new_mock())
-        for key in proxy_db.attrs(coll)["keydep"].keys():
-            proxy_db.attrs(coll)["keydep"][key].add_sub(new_mock(key))
+        # Keydeps are created lazily, so seed them for the existing keys
+        keydeps = proxy_db.attrs(coll)["keydep"]
+        for key in old_keys:
+            keydeps[key] = Dep()
+            keydeps[key].add_sub(new_mock(key))
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         for key in old_keys:
@@ -250,14 +253,18 @@ def test_dict_keynotify():
         mocks.clear()
         coll = DictProxy({2: 3})
         key = args[name][0]
-        is_new_key = key not in proxy_db.attrs(coll)["keydep"]
+        is_new_key = key not in coll.__target__
         proxy_db.attrs(coll)["dep"].add_sub(new_mock())
-        for k in proxy_db.attrs(coll)["keydep"].keys():
-            proxy_db.attrs(coll)["keydep"][k].add_sub(new_mock(k))
+        # Keydeps are created lazily, so seed them for the existing keys
+        keydeps = proxy_db.attrs(coll)["keydep"]
+        for k in coll.__target__.keys():
+            keydeps[k] = Dep()
+            keydeps[k].add_sub(new_mock(k))
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         if is_new_key:
-            assert isinstance(proxy_db.attrs(coll)["keydep"][key], Dep)
+            # Keydeps are created lazily on read, not on write
+            assert key not in proxy_db.attrs(coll)["keydep"]
         else:
             mocks[key].update.assert_called_once()
 
@@ -332,8 +339,11 @@ def test_dict_delete_notify():
         mocks.clear()
         coll = DictProxy({2: 3})
         proxy_db.attrs(coll)["dep"].add_sub(new_mock())
-        for key in proxy_db.attrs(coll)["keydep"].keys():
-            proxy_db.attrs(coll)["keydep"][key].add_sub(new_mock(key))
+        # Keydeps are created lazily, so seed them for the existing keys
+        keydeps = proxy_db.attrs(coll)["keydep"]
+        for key in coll.__target__.keys():
+            keydeps[key] = Dep()
+            keydeps[key].add_sub(new_mock(key))
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         assert len(proxy_db.attrs(coll)["keydep"]) == 1
@@ -356,8 +366,11 @@ def test_dict_delete_keynotify():
         coll = DictProxy({2: 3})
         key = args[name][0]
         proxy_db.attrs(coll)["dep"].add_sub(new_mock())
-        for k in proxy_db.attrs(coll)["keydep"].keys():
-            proxy_db.attrs(coll)["keydep"][k].add_sub(new_mock(k))
+        # Keydeps are created lazily, so seed them for the existing keys
+        keydeps = proxy_db.attrs(coll)["keydep"]
+        for k in coll.__target__.keys():
+            keydeps[k] = Dep()
+            keydeps[k].add_sub(new_mock(k))
         getattr(coll, name)(*args[name])
         mocks[None].update.assert_called_once()
         mocks[key].update.assert_called_once()

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -33,7 +33,16 @@ def test_deps_delete():
     # test that dep objects are _not_ removed on delete
     state = reactive({"foo": 5, "bar": 6})
 
+    # keydeps are created lazily: writes don't create them...
     state["baz"] = 5
+    assert len(proxy_db.attrs(state)["keydep"]) == 0
+
+    # ...but reads with dependency tracking active do
+    @computed
+    def prop():
+        return state["foo"] + state["bar"] + state["baz"]
+
+    assert prop() == 16
     assert len(proxy_db.attrs(state)["keydep"]) == 3
 
     del state["baz"]


### PR DESCRIPTION
Last of the planned performance series following #166. Branched off master, no textual overlap with #167/#168/#169/#170 (touches `write_key_trap`/`delete_key_trap`/`iterate_trap`, while #169 rewrites `write_trap` — different functions in the same file, so git merges them cleanly in any order).

## Lazy keydep creation (the main change)

Proxying a dict eagerly created a `Dep` for every key, making proxy creation O(n) — ~20 ms for a 100k-key dict. Keydeps are now created lazily when a key is read with dependency tracking active (this matches Vue, which creates deps on track). Writes no longer create subscriber-less keydeps either: a keydep without subscribers serves no purpose, and subscribing requires reading the key, which creates it. Once created, keydeps still live forever (per "Don't clean up keydeps at all, like Vue").

Consequences in the traps:
- `write_key_trap` derives `is_new` from the target instead of from keydep presence (which was only equivalent under eager creation) and notifies the keydep only if it exists.
- `delete_key_trap` tolerates a missing keydep.

The white-box tests that subscribed mocks to eagerly created keydeps now seed those keydeps explicitly; `test_deps_delete` additionally documents the lazy-creation lifecycle. Its core assertion — keydeps are never removed on delete — is unchanged.

## Smaller items

- Hoist the `method == "items"` / `method == "setdefault"` string comparisons out of the trap closures (known at trap construction time).
- `operator.attrgetter` instead of a lambda for the sort keys in `Dep.notify` and `Scheduler.flush`.
- Look up the proxy_db entry once in `reference()`/`dereference()` instead of once per access.

## Benchmark results (mean, local run, vs master)

| Benchmark | master | this PR |
|---|---|---|
| `proxy_creation_dict[100k]` | 20.1 ms | 26 µs |
| `proxy_creation_dict[1k]` | 84 µs | 16 µs |
| `proxy_creation_dict[10]` | 27 µs | 15 µs |
| `write_dict_setitem`, `write_dict_new_key` | ~0.9–1.0 µs | ~7% faster |
| `notify_watchers` | — | no measurable change (the sort is a small share of the notify pipeline) |

Full test suite passes (163 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)