### PR TITLE
Notify when a new key is written with a None value

### DIFF
--- a/observ/traps.py
+++ b/observ/traps.py
@@ -202,15 +202,21 @@ def write_key_trap(method, obj_cls):
     def trap(self, *args, **kwargs):
         target = self.__target__
         key = args[0]
-        is_new = key not in target
-        old_value = getitem_fn(target, key) if not is_new else None
+        old_value = getitem_fn(target, key, _MISSING)
         retval = fn(target, *args, **kwargs)
         if is_setdefault and not self.__shallow__:
             # This method is only available when readonly is false
             retval = proxy(retval)
 
         new_value = getitem_fn(target, key)
-        if xor(old_value is None, new_value is None) or old_value != new_value:
+        # The equality check runs only when neither value is _MISSING
+        # or None: some types raise TypeError when compared to None
+        # (e.g. PySide6's ItemFlags), see test_use_weird_types_as_value
+        if old_value is not new_value and (
+            old_value is _MISSING
+            or xor(old_value is None, new_value is None)
+            or old_value != new_value
+        ):
             attrs = proxy_db.attrs(self)
             keydep = attrs["keydep"].get(key)
             if keydep is not None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -439,6 +439,55 @@ def test_dict_update_new_key_with_none_value():
     assert called == 1
 
 
+def test_dict_setitem_new_key_with_none_value():
+    state = reactive({})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: len(state), _expr, sync=True, deep=True)
+
+    state["foo"] = None
+
+    assert state["foo"] is None
+    assert called == 1
+
+    # Assigning the same None value again should not notify
+    state["foo"] = None
+    assert called == 1
+
+
+def test_dict_setdefault_new_key_with_none_value():
+    state = reactive({})
+    called = 0
+
+    def _expr():
+        nonlocal called
+        called += 1
+
+    _ = watch(lambda: len(state), _expr, sync=True, deep=True)
+
+    assert state.setdefault("foo", None) is None
+    assert called == 1
+
+    # The key exists now, so setdefault should not notify
+    assert state.setdefault("foo", "bar") is None
+    assert called == 1
+
+
+def test_dict_setitem_new_key_with_none_value_keydep():
+    state = reactive({})
+    watcher = watch(lambda: "foo" in state, Mock(), sync=True)
+
+    assert watcher.value is False
+
+    state["foo"] = None
+
+    assert watcher.value is True
+
+
 def test_dict_update_with_iterable_of_pairs():
     state = reactive({"foo": "bar"})
     called = 0
@@ -902,6 +951,11 @@ def test_use_weird_types_as_value():
         foo != comparison
 
     a = reactive(dict())
+    a["foo"] = Foo(3)
+
+    # Transitions between None and such a type should not
+    # trigger a comparison with None either
+    a["foo"] = None
     a["foo"] = Foo(3)
 
 


### PR DESCRIPTION
## Problem

`d["new"] = None` and `d.setdefault("new", None)` on a reactive dict did not notify watchers, even though a key was added. `write_key_trap` used `None` as the placeholder for "key did not exist", so a new key with a `None` value compared `None` against `None` and no change was detected.

This is the same quirk that #169 fixed for `update()`; this follow-up applies the same `_MISSING` sentinel to the key-writer path (`__setitem__` / `setdefault`).

## Fix

- `old_value = dict.get(target, key, _MISSING)` distinguishes "key not present" from "value is None" (and replaces the separate `key not in target` containment check, one lookup instead of two).
- The change check becomes: identity changed **and** (key was missing, **or** a None↔non-None transition, **or** values compare unequal).

Behavior preserved deliberately:
- Values are still never compared for equality across a `None` transition or against the sentinel — some types raise `TypeError` when compared to `None` (e.g. PySide6's `ItemFlags`, see `test_use_weird_types_as_value`, which now also covers None↔weird-type transitions).
- Writing an equal value still does not notify.

Side benefit: the leading identity check means re-writing the exact same object never notifies, which fixes a spurious notification for self-unequal values like NaN.

## Tests

- `test_dict_setitem_new_key_with_none_value` — new key set to None notifies once; same None again does not.
- `test_dict_setdefault_new_key_with_none_value` — setdefault with None default notifies; second setdefault does not.
- `test_dict_setitem_new_key_with_none_value_keydep` — a keydep watcher (`"foo" in state`) sees the new None key.
- Extended `test_use_weird_types_as_value` with None↔non-comparable-type transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)