### PR TITLE
Use plain sets for watcher dep bookkeeping

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Container
 from functools import partial, wraps
 from itertools import count
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
-from weakref import WeakSet, ref
+from weakref import ref
 
 from .dep import Dep
 from .proxy import Proxy, proxy
@@ -219,7 +219,13 @@ class Watcher(Generic[T]):
             # or a list of proxies
             if deep is None:
                 deep = True
-        self._deps, self._new_deps = WeakSet(), WeakSet()
+        # Plain sets: WeakSet operations are implemented in Python and
+        # dominate the cost of re-collecting deps on every evaluation.
+        # Strong references are safe here: deps don't reference watchers
+        # strongly (Dep._subs is a WeakSet), and a dep whose container
+        # was garbage collected is dropped on the next cleanup_deps()
+        # or when the watcher is deactivated or collected.
+        self._deps, self._new_deps = set(), set()
         self._tasks = set()
 
         self.sync = sync

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,4 +1,6 @@
-from observ import computed, reactive
+from unittest.mock import Mock
+
+from observ import computed, reactive, watch
 from observ.proxy import proxy_db
 
 
@@ -53,3 +55,32 @@ def test_deps_delete():
 
     state.clear()
     assert len(proxy_db.attrs(state)["keydep"]) == 3
+
+
+def test_deps_released_after_reevaluation():
+    # Watchers hold strong references to their deps, so check that
+    # deps of containers that the watched expression no longer visits
+    # are released when the watcher re-evaluates
+    state = reactive({"foo": {"bar": 5}})
+    watcher = watch(lambda: state, Mock(), sync=True, deep=True)
+
+    # The deep watcher depends on the outer and the nested container
+    assert len(watcher._deps) == 2
+
+    del state["foo"]
+
+    # The sync watcher re-evaluated and dropped
+    # the dep of the nested container
+    assert len(watcher._deps) == 1
+
+
+def test_deps_released_on_deactivation():
+    state = reactive({"foo": 5})
+    watcher = watch(lambda: state["foo"], Mock(), sync=True)
+
+    assert len(watcher._deps) > 0
+
+    # Deactivating the watcher releases its deps
+    watcher()
+
+    assert len(watcher._deps) == 0


### PR DESCRIPTION
## Context

This is the exploratory item 6 from the performance plan (WeakSet→set), gated on profiling after the first five PRs (#167–#171) landed. Profiling master with cProfile on three scenarios showed dep bookkeeping still on top in watcher-heavy workloads:

| Scenario | dep bookkeeping share | of which WeakSet internals |
|---|---|---|
| Deep watcher re-evaluation (2000 leaf mutations) | 31.8% | 16.0% |
| Notify fan-out (1000 sync watchers × 200 mutations) | 39.7% | 19.2% |
| Watcher churn (2000 create+destroy) | 11.9% | 7.3% |

The root cause: `WeakSet` is implemented in pure Python (`_weakrefset.py`), so the two membership checks plus add in `Watcher.add_dep` — which run for every dep touched on every evaluation — are Python function calls (1.2M `WeakSet.__contains__` calls in scenario A alone). Plain `set` does the same in C.

## Change

`Watcher._deps` / `_new_deps` become plain sets. **`Dep._subs` deliberately stays a WeakSet**, which keeps this safe:

- No reference cycles, and watcher lifecycle is unchanged: deleting a watcher still unsubscribes it (deps only hold it weakly).
- The only new behavior is that a watcher briefly keeps Dep objects (not their containers!) alive after the container is collected. Such a dep is inert — nothing can notify it — and it is released on the next re-evaluation (`cleanup_deps`), on deactivation (`watcher()`), or when the watcher itself is collected. Two new tests in `test_deps.py` pin this down.

## Results (local, macOS, CPython 3.14)

| Benchmark | master | this PR | speedup |
|---|---|---|---|
| deep_watch_mutate_leaf[10/100/1k] | 71.8µs / 626µs / 6.79ms | 53.9µs / 453µs / 4.54ms | 1.33–1.49x |
| notify_watchers[10/100/1k] | 33.1µs / 318µs / 3.18ms | 22.1µs / 205µs / 1.98ms | 1.49–1.61x |
| read_dict_getitem_tracked | 91.8µs | 58.2µs | 1.58x |
| untracked reads, plain baselines | — | — | unchanged (±2%) |

Re-profiling with this change: bookkeeping share drops to 10.4% / 18.0% / 5.4% and WeakSet internals to 0.4% / 2.0% / 1.8%. The remainder is the `add_dep`/`cleanup_deps` calls themselves, so I'd consider the riskier second half of the redesign (`Dep._subs` → plain set with explicit unsubscribe) not worth its lifecycle-semantics break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)