### PR TITLE
Speed up the coroutine-function check in watcher creation

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -240,7 +240,7 @@ class Watcher(Generic[T]):
                 self.fn = weak(fn.__self__, fn.__func__)
             else:
                 self.fn = fn
-            self.fn_async = inspect.iscoroutinefunction(fn)
+            self.fn_async = iscoroutinefunction(fn)
         else:
             self.fn = lambda: fn
             self.fn_async = False
@@ -265,7 +265,7 @@ class Watcher(Generic[T]):
                 self.callback = weak(callback.__self__, callback.__func__)
             else:
                 self.callback = callback
-            self.callback_async = inspect.iscoroutinefunction(callback)
+            self.callback_async = iscoroutinefunction(callback)
         else:
             self.callback = callback
             self.callback_async = False
@@ -514,7 +514,7 @@ def weak(obj: Any, method: Callable):
     weak_obj = ref(obj)
 
     sig = inspect.signature(method)
-    iscoro = inspect.iscoroutinefunction(method)
+    iscoro = iscoroutinefunction(method)
     nr_arguments = len(sig.parameters)
 
     if nr_arguments == 1:
@@ -576,3 +576,22 @@ def is_bound_method(fn: Callable):
     Returns whether the given function is a bound method.
     """
     return hasattr(fn, "__self__") and hasattr(fn, "__func__")
+
+
+_CO_COROUTINE = inspect.CO_COROUTINE
+
+
+def iscoroutinefunction(fn: Callable) -> bool:
+    """
+    Same as inspect.iscoroutinefunction, but with a fast path for
+    plain functions and methods (by far the common case), which can
+    be checked directly through their code flags instead of going
+    through the much slower generic inspect machinery.
+    """
+    code = getattr(fn, "__code__", None)
+    if code is None or hasattr(fn, "_is_coroutine_marker"):
+        # No code object (e.g. a functools.partial or another custom
+        # callable), or explicitly marked as a coroutine function with
+        # inspect.markcoroutinefunction: let inspect figure it out
+        return inspect.iscoroutinefunction(fn)
+    return bool(code.co_flags & _CO_COROUTINE)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -226,3 +226,52 @@ def test_computed_pause_resume(noop_request_flush):
     double.__watcher__.resume()
 
     assert double() == 4
+
+
+def test_iscoroutinefunction_parity():
+    # The fast-path coroutine check in observ.watcher must agree with
+    # inspect.iscoroutinefunction for every kind of callable that can
+    # be passed as a watched function or callback
+    import inspect
+    from functools import partial
+
+    from observ.watcher import iscoroutinefunction
+
+    def sync_fn():
+        pass
+
+    async def async_fn():
+        pass
+
+    class Methods:
+        def sync_method(self):
+            pass
+
+        async def async_method(self):
+            pass
+
+        def __call__(self):
+            pass
+
+    instance = Methods()
+    callables = [
+        sync_fn,
+        async_fn,
+        lambda: None,
+        instance.sync_method,
+        instance.async_method,
+        instance,
+        partial(sync_fn),
+        partial(async_fn),
+        print,
+    ]
+    if hasattr(inspect, "markcoroutinefunction"):  # Python >= 3.12
+
+        @inspect.markcoroutinefunction
+        def marked_fn():
+            pass
+
+        callables.append(marked_fn)
+
+    for fn in callables:
+        assert iscoroutinefunction(fn) == inspect.iscoroutinefunction(fn), fn


### PR DESCRIPTION
Follow-up to #177, recovering part of the watcher-creation overhead that was accepted there.

## What

`Watcher.__init__` calls `inspect.iscoroutinefunction` twice — once for the watched function and once for the callback. Each call goes through the generic inspect machinery (`functools.partial` unwrapping, method and function-like checks), which profiling showed accounts for ~500 ns per watcher creation. For plain functions and methods — by far the common case — the answer is available directly from the callable's code flags.

This adds a fast-path `iscoroutinefunction` helper in `observ.watcher` that checks `__code__.co_flags & CO_COROUTINE` directly and only falls back to `inspect.iscoroutinefunction` for callables without a `__code__` attribute (e.g. `functools.partial`, custom callables) or ones explicitly marked with `inspect.markcoroutinefunction` (Python ≥ 3.12). The helper is also used in `weak()`, so bound-method watchers benefit as well.

## Correctness

A new parity test asserts the helper agrees with `inspect.iscoroutinefunction` for every kind of callable that can be watched: plain sync/async functions, lambdas, bound sync/async methods, callable instances, partials wrapping sync/async functions, builtins, and (on 3.12+) `markcoroutinefunction`-decorated functions.

## Result

Watcher creation goes from **5957 → 5116 ns/op** (~14% faster) on the `test_watcher_creation` benchmark setup, measured back-to-back against master on the same machine.

Full test suite passes (210 tests incl. the Qt group), ruff check/format clean.

Note: this narrows, but does not fully close, the `test_watcher_creation` gap accepted in #177 — the Benchmarks gate may still flag that one benchmark against the pre-#177 baseline's spirit, though this PR's own baseline is post-#177 master, against which it is a strict improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4cFbKSCxjGabtJbB9e5H2

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4cFbKSCxjGabtJbB9e5H2)_