### PR TITLE
Make the benchmark CI guard robust against run-to-run noise

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,29 +23,47 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      # On PRs: run benchmarks twice (PR code vs master code) and compare
+      # On PRs: run benchmarks alternating between master code and PR
+      # code (3 runs each), then check that the PR is not *consistently*
+      # slower than master. Single runs are far too noisy to gate on:
+      # process-level effects (hash randomization, memory layout, runner
+      # load) shift individual results by 20-40% on identical code.
+      # Interleaving the runs and comparing the fastest PR run against
+      # the slowest master run makes the guard robust against that noise
+      # (see bench/compare_runs.py).
       - name: Run benchmarks
+        env:
+          # Fixed hash seed: hash randomization moves dict/set benchmark
+          # timings between processes, which would make the master and
+          # PR runs incomparable.
+          PYTHONHASHSEED: "0"
         run: |
-          # Checkout master version of observ directory
           git fetch origin master
-          git checkout origin/master -- observ/
 
-          # Run benchmarks with master code as baseline
-          uv run --no-sync pytest bench \
-              --benchmark-only \
-              --benchmark-save=master \
-              --benchmark-sort=mean || true
+          for i in 1 2 3; do
+            # Run benchmarks with master code as baseline. Tolerate
+            # failures: the PR's benchmarks may exercise APIs that don't
+            # exist on master yet.
+            git checkout origin/master -- observ/
+            uv run --no-sync pytest bench \
+                --benchmark-only \
+                --benchmark-save=master$i \
+                --benchmark-sort=mean || true
 
-          # Restore PR code
-          git checkout HEAD -- observ/
+            # Run benchmarks on PR code
+            git checkout HEAD -- observ/
+            uv run --no-sync pytest bench \
+                --benchmark-only \
+                --benchmark-save=branch$i \
+                --benchmark-sort=mean
+          done
 
-          # Run benchmarks on PR code and compare
-          uv run --no-sync pytest bench \
-              --benchmark-only \
-              --benchmark-compare \
-              --benchmark-compare-fail=mean:5% \
-              --benchmark-save=branch \
-              --benchmark-sort=mean
+      - name: Compare benchmarks
+        run: |
+          uv run --no-sync python bench/compare_runs.py \
+              --baseline '.benchmarks/*/*_master?.json' \
+              --branch '.benchmarks/*/*_branch?.json' \
+              --threshold 0.10
 
       - name: Upload benchmarks
         if: always()

--- a/bench/compare_runs.py
+++ b/bench/compare_runs.py
@@ -1,0 +1,168 @@
+"""
+Compare two sets of pytest-benchmark runs (baseline vs branch) and fail
+when a benchmark has regressed.
+
+Single benchmark runs are too noisy to gate on: process-level effects
+(hash randomization, memory layout, CPU frequency, runner load) shift
+individual timings by 20-40% between runs of identical code. Instead of
+comparing one run against one run, this script expects several
+interleaved runs per side and only reports a regression when the branch
+is *consistently* slower than the baseline:
+
+    fail if min(branch medians) > max(baseline medians) * (1 + threshold)
+
+i.e. the fastest branch run must be slower than the slowest baseline
+run by more than the threshold. A whole-process outlier on either side
+then can't produce a false positive, because the comparison always uses
+the branch's luckiest run against the baseline's unluckiest run.
+
+Usage:
+
+    python bench/compare_runs.py \
+        --baseline '.benchmarks/*/*_master?.json' \
+        --branch '.benchmarks/*/*_branch?.json' \
+        --threshold 0.10
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+from statistics import median
+
+
+def load_runs(pattern):
+    """Load benchmark stats from every file matching the glob pattern.
+
+    Returns a list of runs, each a dict mapping benchmark name to its
+    median timing in seconds.
+    """
+    runs = []
+    for path in sorted(glob.glob(pattern)):
+        with open(path) as fh:
+            data = json.load(fh)
+        runs.append({b["name"]: b["stats"]["median"] for b in data["benchmarks"]})
+    return runs
+
+
+def format_time(seconds):
+    for unit, factor in [("s", 1), ("ms", 1e3), ("us", 1e6), ("ns", 1e9)]:
+        if seconds * factor >= 1:
+            return f"{seconds * factor:,.1f}{unit}"
+    return f"{seconds * 1e9:.2f}ns"
+
+
+def compare(baseline_runs, branch_runs, threshold):
+    """Compare runs and return (rows, failed_names)."""
+    baseline_names = set().union(*(r.keys() for r in baseline_runs))
+    branch_names = set().union(*(r.keys() for r in branch_runs))
+
+    rows = []
+    failed = []
+    for name in sorted(branch_names):
+        if name not in baseline_names:
+            rows.append((name, None, None, None, "new"))
+            continue
+        base = [r[name] for r in baseline_runs if name in r]
+        branch = [r[name] for r in branch_runs if name in r]
+        # Estimated change, for reporting only: middle-of-the-road runs
+        # on both sides.
+        change = (median(branch) - median(base)) / median(base)
+        # Gate: the fastest branch run against the slowest baseline run.
+        excess = (min(branch) - max(base)) / max(base)
+        if excess > threshold:
+            verdict = "FAIL"
+            failed.append(name)
+        else:
+            verdict = ""
+        rows.append((name, base, branch, change, verdict))
+    for name in sorted(baseline_names - branch_names):
+        rows.append((name, None, None, None, "removed"))
+    return rows, failed
+
+
+def render_table(rows, markdown=False):
+    header = ["benchmark", "baseline medians", "branch medians", "change", ""]
+    body = []
+    for name, base, branch, change, verdict in rows:
+        body.append(
+            [
+                name,
+                " / ".join(format_time(t) for t in sorted(base)) if base else "-",
+                " / ".join(format_time(t) for t in sorted(branch)) if branch else "-",
+                f"{change:+.1%}" if change is not None else "-",
+                verdict,
+            ]
+        )
+    if markdown:
+        lines = [
+            "| " + " | ".join(header) + " |",
+            "|" + "|".join("---" for _ in header) + "|",
+        ]
+        lines.extend("| " + " | ".join(row) + " |" for row in body)
+        return "\n".join(lines)
+    widths = [max(len(row[i]) for row in [header, *body]) for i in range(len(header))]
+    lines = [
+        "  ".join(cell.ljust(width) for cell, width in zip(row, widths)).rstrip()
+        for row in [header, *body]
+    ]
+    lines.insert(1, "-" * max(len(line) for line in lines))
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, help="glob for baseline runs")
+    parser.add_argument("--branch", required=True, help="glob for branch runs")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.10,
+        help="max allowed consistent slowdown, as a fraction (default: 0.10)",
+    )
+    args = parser.parse_args(argv)
+
+    baseline_runs = load_runs(args.baseline)
+    branch_runs = load_runs(args.branch)
+
+    if not branch_runs:
+        print(f"error: no branch runs match {args.branch!r}")
+        return 2
+    if not baseline_runs:
+        # The baseline couldn't run at all (e.g. the branch's benchmarks
+        # exercise APIs that don't exist on the baseline yet); there is
+        # nothing to compare against, so pass.
+        print(f"warning: no baseline runs match {args.baseline!r}, skipping compare")
+        return 0
+
+    rows, failed = compare(baseline_runs, branch_runs, args.threshold)
+    print(
+        f"Comparing {len(branch_runs)} branch run(s) against "
+        f"{len(baseline_runs)} baseline run(s), threshold {args.threshold:.0%}:\n"
+    )
+    print(render_table(rows))
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write("## Benchmark comparison\n\n")
+            if failed:
+                fh.write(f"**{len(failed)} benchmark(s) regressed.**\n\n")
+            fh.write(render_table(rows, markdown=True))
+            fh.write("\n")
+
+    if failed:
+        print(
+            f"\n{len(failed)} benchmark(s) consistently slower than baseline "
+            f"by more than {args.threshold:.0%}:"
+        )
+        for name in failed:
+            print(f"  {name}")
+        return 1
+    print("\nNo benchmark consistently regressed beyond the threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,12 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "bench/*" = ["F821"]
+# command line tool that reports through print
+"bench/compare_runs.py" = ["T201"]
 
 [tool.pytest.ini_options]
-addopts = "--benchmark-columns='mean, stddev, rounds'"
+# GC pauses during timed rounds are a major source of benchmark noise
+# (the write traps copy whole containers, generating lots of garbage),
+# so garbage collection is disabled while benchmarks are being timed.
+addopts = "--benchmark-columns='median, mean, stddev, rounds' --benchmark-disable-gc"
 # timeout = 3


### PR DESCRIPTION
The benchmark job compared a single master run against a single PR run
with --benchmark-compare-fail=mean:5%. Measurements show that this can
never pass reliably: on identical code, 25 of 56 benchmarks drift more
than 5% in mean between two back-to-back runs, with swings up to 40%.
Two noise sources dominate:

* GC pauses during timed rounds (the write benchmarks generate a lot
  of garbage), which wreck the mean while leaving the median intact.
* Process-level effects (hash randomization, memory layout, runner
  load) that shift *all* stats of a benchmark by 15-30% between runs,
  which no within-run statistic can compensate.

Address the first class at the source, and the second with a
comparison that is insensitive to per-process outliers:

* Disable GC during timed rounds (--benchmark-disable-gc).
* Pin PYTHONHASHSEED=0 in CI so dict/set timings are comparable
  between processes.
* Run master and PR benchmarks interleaved, 3 runs each (A/B/A/B/A/B),
  instead of once each.
* Replace --benchmark-compare-fail=mean:5% with bench/compare_runs.py,
  which only fails a benchmark when the *fastest* PR run is more than
  10% slower than the *slowest* master run (per-benchmark medians). A
  lucky or unlucky process on either side then can't produce a false
  positive.

Validation on this machine: across interleaved master-vs-master runs
the worst observed "consistent slowdown" is 0.9% (threshold 10%),
while an artificially injected ~50ns overhead in proxy() reliably
fails exactly the four read benchmarks it affects.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TFRf5xWDffeeMoH1gRoeNk