### PR TITLE
Modernize CI workflows: update actions, trim steps, speed up jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,15 +10,14 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+      - name: Install uv and Python 3.14
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.14"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
         run: uv sync
@@ -64,11 +63,3 @@ jobs:
               --baseline '.benchmarks/*/*_master?.json' \
               --branch '.benchmarks/*/*_branch?.json' \
               --threshold 0.10
-
-      - name: Upload benchmarks
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Benchmarks
-          path: .benchmarks/
-          include-hidden-files: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
 
+# Cancel in-flight runs when newer commits are pushed to the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - master
 
+# Cancel in-flight runs when newer commits are pushed to the same
+# branch/PR, but never cancel a tag run mid-publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
             pyversion: "3.13"
           - name: Linux py314
             pyversion: "3.14"
+          # Pre-release of the next CPython, for early feedback ahead of
+          # its stable release. Non-blocking: the job may break on beta
+          # churn without gating PRs.
+          - name: Linux py315 (pre-release)
+            pyversion: "3.15"
+            prerelease: true
+    continue-on-error: ${{ matrix.prerelease == true }}
     steps:
       - uses: actions/checkout@v7
       - name: Install uv and Python ${{ matrix.pyversion }}
@@ -61,7 +68,14 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install -y libgles2-mesa-dev
       - name: Install dependencies
+        if: ${{ !matrix.prerelease }}
         run: uv sync --all-groups
+      # Binary dependencies (PySide6, pygfx, numpy) don't ship wheels
+      # for pre-release CPython; install only the dev group and let the
+      # tests that need them skip themselves.
+      - name: Install dependencies (pre-release Python)
+        if: ${{ matrix.prerelease }}
+        run: uv sync
       - name: Test
         run: uv run --no-sync pytest -v --cov=observ --cov-report=term-missing tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,6 @@ jobs:
             pyversion: "3.13"
           - name: Linux py314
             pyversion: "3.14"
-          # Pre-release of the next CPython, for early feedback ahead of
-          # its stable release. Non-blocking: the job may break on beta
-          # churn without gating PRs.
-          - name: Linux py315 (pre-release)
-            pyversion: "3.15"
-            prerelease: true
-    continue-on-error: ${{ matrix.prerelease == true }}
     steps:
       - uses: actions/checkout@v7
       - name: Install uv and Python ${{ matrix.pyversion }}
@@ -68,14 +61,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install -y libgles2-mesa-dev
       - name: Install dependencies
-        if: ${{ !matrix.prerelease }}
         run: uv sync --all-groups
-      # Binary dependencies (PySide6, pygfx, numpy) don't ship wheels
-      # for pre-release CPython; install only the dev group and let the
-      # tests that need them skip themselves.
-      - name: Install dependencies (pre-release Python)
-        if: ${{ matrix.prerelease }}
-        run: uv sync
       - name: Test
         run: uv run --no-sync pytest -v --cov=observ --cov-report=term-missing tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          python-version-file: "pyproject.toml"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install only dev dependencies
         run: uv sync --only-group ruff
       - name: Lint
@@ -49,13 +48,14 @@ jobs:
           - name: Linux py314
             pyversion: "3.14"
     steps:
-      - uses: actions/checkout@v5
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - name: Set up Python ${{ matrix.pyversion }}
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - name: Install uv and Python ${{ matrix.pyversion }}
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.pyversion }}
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          cache-suffix: py${{ matrix.pyversion }}
       - name: Install system dependencies
         run: |
           sudo apt-get update -y -qq
@@ -71,21 +71,15 @@ jobs:
     name: Build and test wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: "pyproject.toml"
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-      - name: Install dependencies
-        run: uv sync
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Build wheel
         run: uv build
       - name: Twine check
         run: uvx twine check dist/*
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: dist
           name: dist
@@ -102,14 +96,13 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v5
       - name: Download wheel artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
       - name: Release to GitHub
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
-      - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          python-version-file: "pyproject.toml"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install docs dependencies
         run: uv sync --only-group docs
       - name: Build docs


### PR DESCRIPTION
- Bump all actions to latest: checkout v7, setup-uv v8.3.2 (SHA-pinned),
  upload-artifact v7, download-artifact v8, action-gh-release v3 (SHA-pinned)
- Drop actions/setup-python everywhere; uv now provisions Python directly
  via setup-uv's python-version input (faster, one less step)
- Enable uv caching keyed on pyproject.toml (per-Python-version suffix in
  the test matrix) to avoid re-downloading wheels on every run
- Remove unnecessary steps: benchmark artifact upload, `uv sync` in the
  build job (uv build uses an isolated build env), checkout in the
  publish job (release/publish only need the downloaded dist artifact)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F8gB4RkyQ4qiQ4NVyHgZ5b