### PR TITLE
Runtime cleanups split out from the type hinting work

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -52,13 +52,7 @@ Combination of `shallow_reactive` and `readonly`.
 
 ::: observ.watcher.watch
 
-### `watch_effect`
-
-```python
-watch_effect(fn: Callable[[], Any]) -> Watcher
-```
-
-Runs `fn` immediately to collect its dependencies and re-runs it (via the scheduler) whenever they change. Equivalent to `watch(fn, deep=True)` without a callback. See [Watchers](../guide/watchers.md#watch_effect).
+::: observ.watcher.watch_effect
 
 ::: observ.watcher.computed
 

--- a/observ/init.py
+++ b/observ/init.py
@@ -18,6 +18,8 @@ def init(mode="asyncio", loop=None):
         scheduler.register_asyncio(loop)
 
     elif mode == "rendercanvas":
+        if loop is None:
+            raise TypeError("A loop object is required for the 'rendercanvas' mode")
         scheduler.register_rendercanvas(loop)
 
 
@@ -28,6 +30,7 @@ def loop_factory():
     that observ schedules for async functions and callbacks.
     """
     loop = asyncio.new_event_loop()
-    if hasattr(asyncio, "eager_task_factory"):
-        loop.set_task_factory(asyncio.eager_task_factory)
+    eager_task_factory = getattr(asyncio, "eager_task_factory", None)
+    if eager_task_factory is not None:
+        loop.set_task_factory(eager_task_factory)
     return loop

--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from copy import copy, deepcopy
-from functools import partial
-from typing import Generic, Literal, TypedDict, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from .proxy_db import proxy_db
+
+if TYPE_CHECKING:
+    from typing import TypedDict
 
 T = TypeVar("T")
 
@@ -104,32 +106,46 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
     return cast(T, target)
 
 
-try:
-    # for Python >= 3.11
+if TYPE_CHECKING:
+    # Only used for typing: at runtime a Ref is a plain (proxied) dict.
+    # Defined here (instead of unconditionally) because a generic
+    # TypedDict requires Python 3.11
     class Ref(TypedDict, Generic[T]):
         value: T
 
-    def ref(target: T) -> Ref[T]:
-        """
-        Returns a reactive dict with a single 'value' key, set to the
-        given target. Useful for making a single (plain) value reactive.
-        """
-        return proxy(Ref(value=target))
 
-except TypeError:
-    # before python 3.11 a TypedDict cannot inherit from a non-TypedDict class
-    def ref(target: T) -> dict[Literal["value"], T]:
-        """
-        Returns a reactive dict with a single 'value' key, set to the
-        given target. Useful for making a single (plain) value reactive.
-        """
-        return proxy({"value": target})
+def ref(target: T) -> Ref[T]:
+    """
+    Returns a reactive dict with a single 'value' key, set to the
+    given target. Useful for making a single (plain) value reactive.
+    """
+    return proxy(cast("Ref[T]", {"value": target}))
 
 
 reactive = proxy
-readonly = partial(proxy, readonly=True)
-shallow_reactive = partial(proxy, shallow=True)
-shallow_readonly = partial(proxy, shallow=True, readonly=True)
+
+
+def readonly(target: T) -> T:
+    """
+    Returns a readonly proxy for the given target: reads are tracked,
+    but any write raises a ReadonlyError.
+    """
+    return proxy(target, readonly=True)
+
+
+def shallow_reactive(target: T) -> T:
+    """
+    Returns a shallow proxy for the given target: only the first level
+    of the target is made reactive, nested values are returned raw.
+    """
+    return proxy(target, shallow=True)
+
+
+def shallow_readonly(target: T) -> T:
+    """
+    Combination of `shallow_reactive` and `readonly`.
+    """
+    return proxy(target, readonly=True, shallow=True)
 
 
 def to_raw(target: Proxy[T] | T) -> T:

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -10,7 +10,7 @@ import asyncio
 import inspect
 from collections import deque
 from collections.abc import Awaitable, Container
-from functools import partial, wraps
+from functools import wraps
 from itertools import count
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 from weakref import ref
@@ -63,7 +63,17 @@ def watch(
     return watcher
 
 
-watch_effect = partial(watch, immediate=False, deep=True, callback=None)
+def watch_effect(
+    fn: Watchable[T],
+    sync: bool = False,
+    deep: bool = True,
+) -> Watcher[T]:
+    """
+    Run the given function immediately to collect its dependencies
+    and re-run it whenever they change. Equivalent to calling `watch`
+    without a callback.
+    """
+    return watch(fn, callback=None, sync=sync, deep=deep, immediate=False)
 
 
 def computed(_fn: Callable[[], T] | None = None, *, deep=True) -> Callable[[], T]:


### PR DESCRIPTION
Part 1 of 2 for #114: the behavioral/code changes, split out from the pure typing changes (which stack on top of this PR) so each can be reviewed in isolation.

## Changes

* **`watch_effect` is a real function** instead of a `functools.partial`, so it has an inspectable signature, a docstring, and mkdocstrings rendering in the API reference (the hand-written docs section is replaced by the generated one).
* **`readonly`/`shallow_reactive`/`shallow_readonly` are real functions** instead of partials, for the same reason (partials also type-check poorly, which matters for part 2).
* **`ref()` has a single implementation**: the generic `Ref` TypedDict is typing-only (it requires Python 3.11 at runtime, hence the old try/except definition dance), and at runtime a `Ref` was always just a plain (proxied) dict anyway.
* **`init(mode="rendercanvas")` without a loop** raises a clear `TypeError` instead of failing inside `register_rendercanvas`.
* **`loop_factory()`** looks up `asyncio.eager_task_factory` once with `getattr` instead of `hasattr` + attribute access.

No public API changes beyond the partial→function swaps (call sites are unaffected; keyword overrides that the partials accidentally allowed, like `watch_effect(fn, immediate=True)`, are no longer possible).

**Note on `_run_callback`:** an earlier version of this PR also "fixed" a reference-cycle leak in the traceback-introspection code there. On review, that leak didn't exist in the original code — it relied on Python's implicit `del e` at the end of `except TypeError as e:`, which already prevents the frame↔traceback cycle. My rewrite introduced the leak itself by binding `e.__traceback__` to its own local (not covered by that implicit cleanup). `_run_callback` is therefore left untouched here; part 2 handles the one line that needs a type-checker accommodation, via a narrow ignore comment rather than a control-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC