### PR TITLE
Fully implement modern type hinting, checked with ty in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,21 @@ jobs:
       - name: Format
         run: uv run --no-sync ruff format --check .
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install only ty
+        run: uv sync --only-group ty
+      - name: Typecheck
+        run: uv run --no-sync ty check
+
   test:
     name: Test on ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -93,7 +108,7 @@ jobs:
   publish:
     name: Publish to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [lint, typecheck, test, build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,13 @@ repos:
         language: system
         types: [python]
         require_serial: true
+      - id: ty
+        name: Typecheck
+        entry: uv run ty check
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
       - id: pytest
         name: Test
         entry: uv run pytest tests

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * **Automatic dependency tracking** — computed state knows exactly what it depends on and lazily re-evaluates only when needed.
 * **React to any change** — watch plain state or computed state and build unidirectional data flow: state changes drive view changes, input events drive state changes.
 * **Zero dependencies, framework agnostic** — a pure Python library (≥ 3.9) that plugs into any event loop: asyncio, Qt, or your own.
+* **Fully typed** — a [PEP 561](https://peps.python.org/pep-0561/) typed package, checked with [ty](https://github.com/astral-sh/ty) in CI.
 
 ## Quick start
 

--- a/observ/dep.py
+++ b/observ/dep.py
@@ -6,25 +6,28 @@ are attached to observable datastructures.
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 from weakref import WeakSet
+
+if TYPE_CHECKING:
+    from .watcher import Watcher
 
 sub_id = attrgetter("id")
 
 
 class Dep:
     __slots__ = ("__weakref__", "_subs")
-    stack: ClassVar[list["Watcher"]] = []  # noqa: F821
+    stack: ClassVar[list[Watcher]] = []
 
     def __init__(self) -> None:
-        self._subs: WeakSet["Watcher"] = None  # noqa: F821
+        self._subs: WeakSet[Watcher] | None = None
 
-    def add_sub(self, sub: "Watcher") -> None:  # noqa: F821
+    def add_sub(self, sub: Watcher) -> None:
         if self._subs is None:
             self._subs = WeakSet()
         self._subs.add(sub)
 
-    def remove_sub(self, sub: "Watcher") -> None:  # noqa: F821
+    def remove_sub(self, sub: Watcher) -> None:
         if self._subs:
             self._subs.remove(sub)
 

--- a/observ/dict_proxy.py
+++ b/observ/dict_proxy.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
 from .proxy import TYPE_LOOKUP, Proxy
 from .traps import construct_methods_traps_dict, trap_map, trap_map_readonly
 
-dict_traps = {
+dict_traps: dict[str, set[str]] = {
     "READERS": {
         "copy",
         "__eq__",
@@ -52,35 +56,45 @@ dict_traps = {
 class DictProxyBase(Proxy[dict]):
     __slots__ = ()
 
-    def _orphaned_keydeps(self):
+    def _orphaned_keydeps(self) -> set[Any]:
         keydeps = self.__dep__.keydeps
         if keydeps is None:
             return set()
         return set(keydeps.keys()) - set(self.__target__.keys())
 
 
-def readonly_dict_proxy_init(self, target, shallow=False, **kwargs):
+def readonly_dict_proxy_init(
+    self: DictProxyBase, target: dict, shallow: bool = False, **kwargs: Any
+) -> None:
     super(ReadonlyDictProxy, self).__init__(
         target, shallow=shallow, **{**kwargs, "readonly": True}
     )
 
 
-DictProxy = type(
-    "DictProxy",
-    (DictProxyBase,),
-    {
-        "__slots__": (),
-        **construct_methods_traps_dict(dict, dict_traps, trap_map),
-    },
+# The proxy classes are assembled dynamically from the trap functions,
+# which the type system cannot see; cast them to their actual shape
+DictProxy = cast(
+    "type[DictProxyBase]",
+    type(
+        "DictProxy",
+        (DictProxyBase,),
+        {
+            "__slots__": (),
+            **construct_methods_traps_dict(dict, dict_traps, trap_map),
+        },
+    ),
 )
-ReadonlyDictProxy = type(
-    "ReadonlyDictProxy",
-    (DictProxyBase,),
-    {
-        "__slots__": (),
-        "__init__": readonly_dict_proxy_init,
-        **construct_methods_traps_dict(dict, dict_traps, trap_map_readonly),
-    },
+ReadonlyDictProxy = cast(
+    "type[DictProxyBase]",
+    type(
+        "ReadonlyDictProxy",
+        (DictProxyBase,),
+        {
+            "__slots__": (),
+            "__init__": readonly_dict_proxy_init,
+            **construct_methods_traps_dict(dict, dict_traps, trap_map_readonly),
+        },
+    ),
 )
 
 

--- a/observ/init.py
+++ b/observ/init.py
@@ -1,9 +1,20 @@
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
 from .scheduler import scheduler
 
+if TYPE_CHECKING:
+    from typing import Literal
 
-def init(mode="asyncio", loop=None):
+    from .scheduler import SupportsCallSoon
+
+
+def init(
+    mode: Literal["asyncio", "qt", "rendercanvas"] = "asyncio",
+    loop: SupportsCallSoon | None = None,
+) -> None:
     """
     Integrate the scheduler with an event loop, so that watcher
     callbacks are batched and run on the loop. Supported modes are
@@ -23,7 +34,7 @@ def init(mode="asyncio", loop=None):
         scheduler.register_rendercanvas(loop)
 
 
-def loop_factory():
+def loop_factory() -> asyncio.AbstractEventLoop:
     """
     Creates a new asyncio event loop with the eager task factory
     enabled (Python 3.12+), which reduces the latency of the tasks

--- a/observ/list_proxy.py
+++ b/observ/list_proxy.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
 from .proxy import TYPE_LOOKUP, Proxy
 from .traps import construct_methods_traps_dict, trap_map, trap_map_readonly
 
-list_traps = {
+list_traps: dict[str, set[str]] = {
     "READERS": {
         "count",
         "index",
@@ -48,28 +52,38 @@ class ListProxyBase(Proxy[list]):
     __slots__ = ()
 
 
-def readonly_list_proxy_init(self, target, shallow=False, **kwargs):
+def readonly_list_proxy_init(
+    self: ListProxyBase, target: list, shallow: bool = False, **kwargs: Any
+) -> None:
     super(ReadonlyListProxy, self).__init__(
         target, shallow=shallow, **{**kwargs, "readonly": True}
     )
 
 
-ListProxy = type(
-    "ListProxy",
-    (ListProxyBase,),
-    {
-        "__slots__": (),
-        **construct_methods_traps_dict(list, list_traps, trap_map),
-    },
+# The proxy classes are assembled dynamically from the trap functions,
+# which the type system cannot see; cast them to their actual shape
+ListProxy = cast(
+    "type[ListProxyBase]",
+    type(
+        "ListProxy",
+        (ListProxyBase,),
+        {
+            "__slots__": (),
+            **construct_methods_traps_dict(list, list_traps, trap_map),
+        },
+    ),
 )
-ReadonlyListProxy = type(
-    "ReadonlyListProxy",
-    (ListProxyBase,),
-    {
-        "__slots__": (),
-        "__init__": readonly_list_proxy_init,
-        **construct_methods_traps_dict(list, list_traps, trap_map_readonly),
-    },
+ReadonlyListProxy = cast(
+    "type[ListProxyBase]",
+    type(
+        "ReadonlyListProxy",
+        (ListProxyBase,),
+        {
+            "__slots__": (),
+            "__init__": readonly_list_proxy_init,
+            **construct_methods_traps_dict(list, list_traps, trap_map_readonly),
+        },
+    ),
 )
 
 

--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from .proxy_db import proxy_db
 
 if TYPE_CHECKING:
     from typing import TypedDict
+
+    from .proxy_db import TargetDep
 
 T = TypeVar("T")
 
@@ -27,38 +29,42 @@ class Proxy(Generic[T]):
     or return an existing proxy and makes sure that the db stays consistent.
     """
 
-    __hash__ = None
+    __hash__ = None  # type: ignore[assignment]
     # the slots have to be very unique since we also proxy objects
-    # which may define the attributes with the same names
+    # which may define the attributes with the same names.
+    # NB: deliberately not annotated in the class body (the slot types
+    # are inferred from __init__): class-level annotations would add an
+    # __annotations__ attribute to the class, which would leak through
+    # to the container proxies (see test_wrapping_complete)
     __slots__ = ("__dep__", "__readonly__", "__shallow__", "__target__", "__weakref__")
 
-    def __init__(self, target: T, readonly=False, shallow=False):
+    def __init__(self, target: T, readonly: bool = False, shallow: bool = False):
         self.__target__ = target
         self.__readonly__ = readonly
         self.__shallow__ = shallow
-        dep = proxy_db.target_dep(target)
+        dep: TargetDep = proxy_db.target_dep(target)
         dep.register_proxy((readonly, shallow), self)
         self.__dep__ = dep
 
     def __copy__(self) -> T:
         return copy(self.__target__)
 
-    def __deepcopy__(self, memo: dict) -> T:
+    def __deepcopy__(self, memo: dict[int, Any]) -> T:
         return deepcopy(self.__target__, memo)
 
 
 # Lookup dict for mapping a type (dict, list, set) to a tuple
 # of proxy types (writable, readonly) for that type. Keyed on the
 # exact type, so subclasses are (deliberately) not proxied
-TYPE_LOOKUP = {}
+TYPE_LOOKUP: dict[type, tuple[type[Proxy[Any]], type[Proxy[Any]]]] = {}
 
 # Types of values that can't be proxied. Note the exact type is
 # checked (no subclasses) so that these can be ruled out with a
 # single set containment check
-PLAIN_TYPES = frozenset({type(None), bool, int, float, str, bytes})
+PLAIN_TYPES: frozenset[type] = frozenset({type(None), bool, int, float, str, bytes})
 
 
-def proxy(target: T, readonly=False, shallow=False) -> T:
+def proxy(target: T, readonly: bool = False, shallow: bool = False) -> T:
     """
     Returns a Proxy for the given object. If a proxy for the given
     configuration already exists, it will return that instead of
@@ -67,6 +73,14 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
     Please be aware: this only works on plain data types: dict, list,
     set and tuple!
     """
+    # Note on the typing in this function: a proxy behaves exactly like
+    # its target (all methods are delegated to it), but the type system
+    # cannot express that relationship, so proxy-creating functions are
+    # typed as returning the target's own type (see also the discussion
+    # in https://github.com/fork-tongue/observ/pull/111). Since this is
+    # the hottest code path in observ, Any-typed locals are used instead
+    # of typing.cast, which would incur a function call at runtime
+
     # Plain values can't be proxied, so return them as-is. This is the
     # most common case since this function is called on the result of
     # every read from a proxied container, so it is checked first
@@ -83,11 +97,12 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
             # unwrap the target from the proxy so that the right
             # kind of proxy can be returned in the next part of
             # this function
-            target = target.__target__
+            unwrapped: Any = target.__target__
+            target = unwrapped
 
     # Note that at this point, target is always a non-proxy object
     # Check the proxy_db to see if there's already a proxy for the target object
-    existing_proxy = proxy_db.get_proxy(target, readonly=readonly, shallow=shallow)
+    existing_proxy: Any = proxy_db.get_proxy(target, readonly=readonly, shallow=shallow)
     if existing_proxy is not None:
         return existing_proxy
 
@@ -95,7 +110,8 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
     proxy_types = TYPE_LOOKUP.get(type(target))
     if proxy_types is not None:
         proxy_type = proxy_types[1] if readonly else proxy_types[0]
-        return proxy_type(target, readonly=readonly, shallow=shallow)
+        new_proxy: Any = proxy_type(target, readonly=readonly, shallow=shallow)
+        return new_proxy
 
     if isinstance(target, tuple):
         return cast(
@@ -103,7 +119,7 @@ def proxy(target: T, readonly=False, shallow=False) -> T:
         )
 
     # We can't proxy a plain value
-    return cast(T, target)
+    return target
 
 
 if TYPE_CHECKING:
@@ -153,6 +169,9 @@ def to_raw(target: Proxy[T] | T) -> T:
     Returns a raw object from which any trace of proxy has been replaced
     with its wrapped target value.
     """
+    # The casts below are needed because the type system cannot know
+    # that rebuilding a container from its (recursively unproxied)
+    # items yields a value of the same type as the original target
     if isinstance(target, Proxy):
         return to_raw(target.__target__)
 

--- a/observ/proxy_db.py
+++ b/observ/proxy_db.py
@@ -27,9 +27,18 @@ the TargetDep for its previous target has already been destroyed
 and has removed itself from the registry.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from weakref import WeakValueDictionary, ref
 
 from .dep import Dep
+
+if TYPE_CHECKING:
+    from .proxy import Proxy
+
+    # A proxy configuration: the (readonly, shallow) flags
+    ProxyConfig = tuple[bool, bool]
 
 
 class TargetDep(Dep):
@@ -42,7 +51,10 @@ class TargetDep(Dep):
 
     __slots__ = ("keydeps", "proxies", "target")
 
-    def __init__(self, target):
+    keydeps: WeakValueDictionary[Any, KeyDep] | None
+    proxies: dict[ProxyConfig, ref[Proxy[Any]]]
+
+    def __init__(self, target: Any) -> None:
         super().__init__()
         self.target = target
         # Per-key deps (dict targets only). Starts out as None and is
@@ -57,7 +69,7 @@ class TargetDep(Dep):
         # keyed on (readonly, shallow)
         self.proxies = {}
 
-    def keydep(self, key):
+    def keydep(self, key: Any) -> KeyDep:
         """
         Returns the dep for the given key, creating it if needed.
         Note that the keydeps mapping is weak: the returned dep stays
@@ -75,7 +87,7 @@ class TargetDep(Dep):
         keydeps[key] = keydep
         return keydep
 
-    def register_proxy(self, config, proxy):
+    def register_proxy(self, config: ProxyConfig, proxy: Proxy[Any]) -> None:
         """
         Registers the proxy as the proxy that wraps the target with
         the given (readonly, shallow) configuration. There can be only
@@ -86,13 +98,17 @@ class TargetDep(Dep):
         if existing is not None and existing() is not None:
             raise RuntimeError("Proxy with existing configuration already in db")
 
-        def remove(weak_proxy, proxies=proxies, config=config):
+        def remove(
+            weak_proxy: ref[Proxy[Any]],
+            proxies: dict[ProxyConfig, ref[Proxy[Any]]] = proxies,
+            config: ProxyConfig = config,
+        ) -> None:
             if proxies.get(config) is weak_proxy:
                 del proxies[config]
 
         proxies[config] = ref(proxy, remove)
 
-    def get_proxy(self, config):
+    def get_proxy(self, config: ProxyConfig) -> Proxy[Any] | None:
         """
         Returns the proxy that wraps the target with the given
         (readonly, shallow) configuration, or None if there is none.
@@ -113,7 +129,7 @@ class KeyDep(Dep):
 
     __slots__ = ("owner",)
 
-    def __init__(self, owner):
+    def __init__(self, owner: TargetDep) -> None:
         super().__init__()
         self.owner = owner
 
@@ -127,11 +143,11 @@ class ProxyDb:
 
     __slots__ = ("db",)
 
-    def __init__(self):
+    def __init__(self) -> None:
         # id(target) -> weakref to the TargetDep for that target
-        self.db = {}
+        self.db: dict[int, ref[TargetDep]] = {}
 
-    def target_dep(self, target):
+    def target_dep(self, target: Any) -> TargetDep:
         """
         Returns the TargetDep for the given target, creating it (and
         registering it) if there is none yet.
@@ -146,7 +162,11 @@ class ProxyDb:
 
         dep = TargetDep(target)
 
-        def remove(weak_dep, db=db, obj_id=obj_id):
+        def remove(
+            weak_dep: ref[TargetDep],
+            db: dict[int, ref[TargetDep]] = db,
+            obj_id: int = obj_id,
+        ) -> None:
             # Guard against the entry having been replaced in the
             # meantime, so a stale callback can't remove a live entry
             if db.get(obj_id) is weak_dep:
@@ -155,7 +175,9 @@ class ProxyDb:
         db[obj_id] = ref(dep, remove)
         return dep
 
-    def get_proxy(self, target, readonly=False, shallow=False):
+    def get_proxy(
+        self, target: Any, readonly: bool = False, shallow: bool = False
+    ) -> Proxy[Any] | None:
         """
         Returns the proxy with the given configuration for the given
         target. Will return None if there is no such proxy.

--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -3,14 +3,33 @@ The scheduler queues up and deduplicates re-evaluation of lazy Watchers
 and should be integrated in the event loop of your choosing.
 """
 
+from __future__ import annotations
+
 import asyncio
 import importlib
 import warnings
 from bisect import bisect
 from collections import defaultdict
 from operator import attrgetter
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .watcher import Watcher
 
 watcher_id = attrgetter("id")
+
+
+class SupportsCallSoon(Protocol):
+    """
+    The part of the (asyncio or rendercanvas) event loop interface
+    that the scheduler needs to schedule flushes.
+    """
+
+    def call_soon(self, callback: Callable[[], Any]) -> object: ...
+
+    def call_soon_threadsafe(self, callback: Callable[[], Any]) -> object: ...
 
 
 class Scheduler:
@@ -28,7 +47,18 @@ class Scheduler:
         "waiting",
     )
 
-    def __init__(self):
+    _queue: list[Watcher[Any]]
+    _queue_indices: list[int]
+    circular: defaultdict[int, int]
+    detect_cycles: bool
+    flushing: bool
+    has: set[int]
+    index: int
+    request_flush: Callable[[], Any]
+    timer: Any
+    waiting: bool
+
+    def __init__(self) -> None:
         self._queue = []
         self._queue_indices = []
         self.flushing = False
@@ -39,23 +69,23 @@ class Scheduler:
         self.request_flush = self.request_flush_raise
         self.detect_cycles = True
 
-    def request_flush_raise(self):
+    def request_flush_raise(self) -> None:
         """
         Error raising default request flusher.
         """
         raise ValueError("No flush request handler registered")
 
-    def register_request_flush(self, callback):
+    def register_request_flush(self, callback: Callable[[], Any]) -> None:
         """
         Register callback for registering a call to flush
         """
         self.request_flush = callback
 
-    def request_flush_asyncio(self):
+    def request_flush_asyncio(self) -> None:
         loop = asyncio.get_event_loop()
         loop.call_soon_threadsafe(self.flush)
 
-    def register_asyncio(self, loop=None):
+    def register_asyncio(self, loop: SupportsCallSoon | None = None) -> None:
         """
         Utility function for integration with asyncio.
 
@@ -67,7 +97,7 @@ class Scheduler:
         else:
             self.register_request_flush(self.request_flush_asyncio)
 
-    def register_qt(self):
+    def register_qt(self) -> None:
         """
         Legacy utility function for integration with Qt event loop. Note that using
         the `register_asyncio` method is preferred over this, together with
@@ -105,7 +135,7 @@ class Scheduler:
         self.timer.setInterval(0)
         self.register_request_flush(self.timer.start)
 
-    def register_rendercanvas(self, loop):
+    def register_rendercanvas(self, loop: SupportsCallSoon) -> None:
         """
         Utility function for integration with rendercanvas loop objects
         """
@@ -117,7 +147,7 @@ class Scheduler:
         # Since rc loop objects look similar to asyncio, we can reuse the method
         self.register_asyncio(loop)
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Flush the queue to evaluate all queued watchers.
         You can call this manually, or register a callback
@@ -148,7 +178,7 @@ class Scheduler:
 
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         self._queue.clear()
         self._queue_indices.clear()
         self.flushing = False
@@ -157,7 +187,7 @@ class Scheduler:
         self.circular.clear()
         self.index = 0
 
-    def queue(self, watcher: "Watcher"):  # noqa: F821
+    def queue(self, watcher: Watcher[Any]) -> None:
         if watcher.id in self.has:
             return
 

--- a/observ/set_proxy.py
+++ b/observ/set_proxy.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
 from .proxy import TYPE_LOOKUP, Proxy
 from .traps import construct_methods_traps_dict, trap_map, trap_map_readonly
 
-set_traps = {
+set_traps: dict[str, set[str]] = {
     "READERS": {
         "copy",
         "difference",
@@ -57,25 +61,35 @@ class SetProxyBase(Proxy[set]):
     __slots__ = ()
 
 
-def readonly_set_proxy_init(self, target, shallow=False, **kwargs):
+def readonly_set_proxy_init(
+    self: SetProxyBase, target: set, shallow: bool = False, **kwargs: Any
+) -> None:
     super(ReadonlySetProxy, self).__init__(
         target, shallow=shallow, **{**kwargs, "readonly": True}
     )
 
 
-SetProxy = type(
-    "SetProxy",
-    (SetProxyBase,),
-    {"__slots__": (), **construct_methods_traps_dict(set, set_traps, trap_map)},
+# The proxy classes are assembled dynamically from the trap functions,
+# which the type system cannot see; cast them to their actual shape
+SetProxy = cast(
+    "type[SetProxyBase]",
+    type(
+        "SetProxy",
+        (SetProxyBase,),
+        {"__slots__": (), **construct_methods_traps_dict(set, set_traps, trap_map)},
+    ),
 )
-ReadonlySetProxy = type(
-    "ReadonlysetProxy",
-    (SetProxyBase,),
-    {
-        "__slots__": (),
-        "__init__": readonly_set_proxy_init,
-        **construct_methods_traps_dict(set, set_traps, trap_map_readonly),
-    },
+ReadonlySetProxy = cast(
+    "type[SetProxyBase]",
+    type(
+        "ReadonlysetProxy",
+        (SetProxyBase,),
+        {
+            "__slots__": (),
+            "__init__": readonly_set_proxy_init,
+            **construct_methods_traps_dict(set, set_traps, trap_map_readonly),
+        },
+    ),
 )
 
 

--- a/observ/traps.py
+++ b/observ/traps.py
@@ -1,8 +1,23 @@
+from __future__ import annotations
+
 from functools import partial, wraps
 from operator import xor
+from typing import TYPE_CHECKING, Any
 
 from .dep import Dep
-from .proxy import proxy
+from .proxy import Proxy, proxy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .dict_proxy import DictProxyBase
+
+    # A trap wraps a method of a container type (dict, list or set)
+    # with dependency tracking and/or change notification
+    Trap = Callable[..., Any]
+    # A trap factory builds a trap for the given method of the
+    # given container type
+    TrapFactory = Callable[[str, type], Trap]
 
 
 class ReadonlyError(Exception):
@@ -13,11 +28,11 @@ class ReadonlyError(Exception):
     pass
 
 
-def read_trap(method, obj_cls):
+def read_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         if Dep.stack:
             self.__dep__.depend()
         value = fn(self.__target__, *args, **kwargs)
@@ -28,13 +43,13 @@ def read_trap(method, obj_cls):
     return trap
 
 
-def iterate_trap(method, obj_cls):
+def iterate_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
     # Hoist the method check out of the trap
     is_items = method == "items"
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         if Dep.stack:
             self.__dep__.depend()
         iterator = fn(self.__target__, *args, **kwargs)
@@ -52,11 +67,11 @@ def iterate_trap(method, obj_cls):
     return trap
 
 
-def read_key_trap(method, obj_cls):
+def read_key_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         if Dep.stack:
             self.__dep__.keydep(args[0]).depend()
         value = fn(self.__target__, *args, **kwargs)
@@ -75,7 +90,7 @@ _MISSING = object()
 _NO_KEYDEPS = {}
 
 
-def write_trap(method, obj_cls):
+def write_trap(method: str, obj_cls: type) -> Trap:
     """
     Returns a trap with the cheapest change detection strategy that
     is correct for the given method, so that writes don't need a copy
@@ -97,11 +112,11 @@ def write_trap(method, obj_cls):
     return write_len_compare_trap(method, obj_cls)
 
 
-def write_dict_trap(method, obj_cls):
+def write_dict_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         target = self.__target__
         # Normalize the arguments (an optional mapping or iterable of
         # key/value pairs, plus optional keyword arguments) into a
@@ -132,11 +147,11 @@ def write_dict_trap(method, obj_cls):
     return trap
 
 
-def write_len_compare_trap(method, obj_cls):
+def write_len_compare_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         target = self.__target__
         old_len = len(target)
         retval = fn(target, *args, **kwargs)
@@ -147,11 +162,11 @@ def write_len_compare_trap(method, obj_cls):
     return trap
 
 
-def write_copy_compare_trap(method, obj_cls):
+def write_copy_compare_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         target = self.__target__
         old = target.copy()
         retval = fn(target, *args, **kwargs)
@@ -162,11 +177,11 @@ def write_copy_compare_trap(method, obj_cls):
     return trap
 
 
-def write_setitem_trap(method, obj_cls):
+def write_setitem_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, key, value):
+    def trap(self: Proxy[Any], key: Any, value: Any) -> Any:
         target = self.__target__
         try:
             old_value = target[key]
@@ -190,14 +205,14 @@ def write_setitem_trap(method, obj_cls):
     return trap
 
 
-def write_key_trap(method, obj_cls):
+def write_key_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
     getitem_fn = getattr(obj_cls, "get")
     # Hoist the method check out of the trap
     is_setdefault = method == "setdefault"
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         target = self.__target__
         key = args[0]
         old_value = getitem_fn(target, key, _MISSING)
@@ -227,11 +242,11 @@ def write_key_trap(method, obj_cls):
     return trap
 
 
-def delete_trap(method, obj_cls):
+def delete_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: DictProxyBase, *args: Any, **kwargs: Any) -> Any:
         retval = fn(self.__target__, *args, **kwargs)
         dep = self.__dep__
         dep.notify()
@@ -247,11 +262,11 @@ def delete_trap(method, obj_cls):
     return trap
 
 
-def delete_key_trap(method, obj_cls):
+def delete_key_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         key = args[0]
         key_existed = key in self.__target__
         retval = fn(self.__target__, *args, **kwargs)
@@ -268,7 +283,7 @@ def delete_key_trap(method, obj_cls):
     return trap
 
 
-trap_map = {
+trap_map: dict[str, TrapFactory] = {
     "READERS": read_trap,
     "KEYREADERS": read_key_trap,
     "ITERATORS": iterate_trap,
@@ -279,17 +294,17 @@ trap_map = {
 }
 
 
-def readonly_trap(method, obj_cls):
+def readonly_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self, *args, **kwargs):
+    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         raise ReadonlyError()
 
     return trap
 
 
-trap_map_readonly = {
+trap_map_readonly: dict[str, TrapFactory] = {
     "READERS": read_trap,
     "KEYREADERS": read_key_trap,
     "ITERATORS": iterate_trap,
@@ -300,7 +315,9 @@ trap_map_readonly = {
 }
 
 
-def construct_methods_traps_dict(obj_cls, traps, trap_map):
+def construct_methods_traps_dict(
+    obj_cls: type, traps: dict[str, set[str]], trap_map: dict[str, TrapFactory]
+) -> dict[str, Trap]:
     return {
         method: trap_map[trap_type](method, obj_cls)
         for trap_type, methods in traps.items()

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections import deque
-from collections.abc import Awaitable, Container
+from collections.abc import Container
 from functools import wraps
 from itertools import count
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 from weakref import ref
 
 from .dep import Dep
@@ -21,12 +21,30 @@ from .proxy_db import proxy_db
 from .scheduler import scheduler
 
 T = TypeVar("T")
-Watchable = Union[
-    Callable[[], T],
-    Callable[[], Awaitable[T]],
-    T,
-]
-WatchCallback = Union[Callable[[], Any], Callable[[T], Any], Callable[[T, T], Any]]
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from types import MethodType
+    from typing import ClassVar, Protocol
+
+    from typing_extensions import TypeIs
+
+    # Something that can be watched: a function (which doesn't have to
+    # return anything) or a coroutine function, or a proxy (or other
+    # container of proxies), which implies deep watching
+    Watchable = Callable[[], T] | Callable[[], Awaitable[T]] | T
+    # Callbacks may accept zero, one (new value) or two
+    # (new and old value) arguments
+    WatchCallback = Callable[[], Any] | Callable[[T], Any] | Callable[[T, T], Any]
+
+    class Computed(Protocol[T]):
+        """
+        The cached getter returned by `computed`.
+        """
+
+        __watcher__: Watcher[T]
+
+        def __call__(self) -> T: ...
 
 
 def watch(
@@ -76,7 +94,17 @@ def watch_effect(
     return watch(fn, callback=None, sync=sync, deep=deep, immediate=False)
 
 
-def computed(_fn: Callable[[], T] | None = None, *, deep=True) -> Callable[[], T]:
+@overload
+def computed(_fn: Callable[[], T]) -> Computed[T]: ...
+
+
+@overload
+def computed(*, deep: bool = True) -> Callable[[Callable[[], T]], Computed[T]]: ...
+
+
+def computed(
+    _fn: Callable[[], T] | None = None, *, deep: bool = True
+) -> Computed[T] | Callable[[Callable[[], T]], Computed[T]]:
     """
     Create derived state from a function: the result is cached and
     only recomputed (lazily) when any of the reactive state it depends
@@ -86,26 +114,34 @@ def computed(_fn: Callable[[], T] | None = None, *, deep=True) -> Callable[[], T
     reactive state is changed within the function.
     """
 
-    def decorator_computed(fn: Callable[[], T]) -> Callable[[], T]:
-        watcher = Watcher(fn, deep=deep)
+    def decorator_computed(fn: Callable[[], T]) -> Computed[T]:
+        # The cast pins T for the watcher: inference against the
+        # Watchable union cannot rule out that fn is a watched (plain)
+        # callable value rather than the function to evaluate
+        watcher = cast("Watcher[T]", Watcher(fn, deep=deep))
 
         @wraps(fn)
-        def getter():
+        def getter() -> T:
             if watcher.dirty:
                 watcher.evaluate()
             if Dep.stack:
                 watcher.depend()
-            return watcher.value
+            # An Any-typed local instead of typing.cast, which would
+            # incur a function call at runtime in this hot path (the
+            # value is a T here: the watcher has been evaluated)
+            value: Any = watcher.value
+            return value
 
-        getter.__watcher__ = watcher
-        return getter
+        computed_getter = cast("Computed[T]", getter)
+        computed_getter.__watcher__ = watcher
+        return computed_getter
 
     if _fn is None:
         return decorator_computed
     return decorator_computed(_fn)
 
 
-def traverse(obj):
+def traverse(obj: Any) -> None:
     """
     Non-recursively traverse the whole tree to make sure that the dep of
     every (nested) container has been depended on.
@@ -133,8 +169,8 @@ def traverse(obj):
     tree that is being traversed, so ids can't be reused for the
     duration of this method.
     """
-    seen_ids = set()
-    stack = deque([(obj, False)])
+    seen_ids: set[int] = set()
+    stack: deque[tuple[Any, bool]] = deque([(obj, False)])
     db = proxy_db.db
     track = bool(Dep.stack)
 
@@ -224,8 +260,31 @@ class Watcher(Generic[T]):
         "sync",
         "value",
     )
-    on_created: Optional[Callable[[Watcher[T]], None]] = None
-    on_destroyed: Optional[Callable[[Watcher[T]], None]] = None
+
+    id: int
+    _active: bool
+    _paused: bool
+    _pending_update: bool
+    # The watched function, normalized to a plain callable: a watched
+    # plain value or proxy is wrapped in a lambda, a bound method in a
+    # weakref-checking wrapper, and stop() resets it to a stub
+    fn: Callable[[], Any]
+    fn_async: bool
+    _deps: set[Dep]
+    _new_deps: set[Dep]
+    _tasks: set[asyncio.Task[Any]]
+    sync: bool
+    callback: Callable[..., Any] | None
+    callback_async: bool
+    no_recurse: bool
+    deep: bool
+    lazy: bool
+    dirty: bool
+    value: T | None
+    _number_of_callback_args: int | None
+
+    on_created: ClassVar[Callable[[Watcher[Any]], None] | None] = None
+    on_destroyed: ClassVar[Callable[[Watcher[Any]], None] | None] = None
 
     def __init__(
         self,
@@ -249,7 +308,10 @@ class Watcher(Generic[T]):
             if is_bound_method(fn):
                 self.fn = weak(fn.__self__, fn.__func__)
             else:
-                self.fn = fn
+                # A callable fn is always a 0-arg (or coroutine)
+                # function, which the type system cannot infer from
+                # the Watchable union
+                self.fn = cast("Callable[[], Any]", fn)
             self.fn_async = inspect.iscoroutinefunction(fn)
         else:
             self.fn = lambda: fn
@@ -289,7 +351,7 @@ class Watcher(Generic[T]):
         if Watcher.on_created:
             Watcher.on_created(self)
 
-    def __call__(self):
+    def __call__(self) -> None:
         """
         Calling a watcher will stop the watcher and clean up
         any used resource. This can be used when special
@@ -336,12 +398,12 @@ class Watcher(Generic[T]):
             self._pending_update = False
             self.update()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if Watcher.on_destroyed:
             Watcher.on_destroyed(self)
 
     @property
-    def active(self):
+    def active(self) -> bool:
         """
         Returns whether this watcher is still active.
         To manually deactivate simply call the watcher object.
@@ -349,7 +411,7 @@ class Watcher(Generic[T]):
         return self._active
 
     @property
-    def paused(self):
+    def paused(self) -> bool:
         """
         Returns whether this watcher is currently paused.
         Use `pause()` and `resume()` to control this state.
@@ -393,7 +455,7 @@ class Watcher(Generic[T]):
             if self.callback:
                 self.run_callback(self.value, old_value)
 
-    def run_callback(self, new, old) -> None:
+    def run_callback(self, new: T | None, old: T | None) -> None:
         """
         Runs the callback. When the number of arguments is still unknown
         for the callback, it will fall into the try/except contstruct
@@ -402,13 +464,16 @@ class Watcher(Generic[T]):
         is known and the callback can be called with the correct
         amount of arguments.
         """
+        callback = self.callback
+        assert callback is not None
+        maybe_coro: Any = None
         if self._number_of_callback_args is not None:
             if self._number_of_callback_args == 1:
-                maybe_coro = self.callback(new)
+                maybe_coro = callback(new)
             elif self._number_of_callback_args == 2:
-                maybe_coro = self.callback(new, old)
+                maybe_coro = callback(new, old)
             elif self._number_of_callback_args == 0:
-                maybe_coro = self.callback()
+                maybe_coro = callback()
 
         else:
             try:
@@ -437,7 +502,7 @@ class Watcher(Generic[T]):
                 self._tasks.add(task)
                 task.add_done_callback(self._tasks.discard)
 
-    def _run_callback(self, *args) -> None:
+    def _run_callback(self, *args: Any) -> Any:
         """
         Run the callback with the given arguments. When the callback
         raises a TypeError, check to see if the error results from
@@ -446,17 +511,29 @@ class Watcher(Generic[T]):
         Raises WrongNumberOfArgumentsError if callback was called
         with the wrong number of arguments.
         """
+        callback = self.callback
+        assert callback is not None
         try:
-            return self.callback(*args)
+            return callback(*args)
         except TypeError as e:
             # figure out if the TypeError was caused by wrong number of arguments
             # by checking the exception's traceback
             wrong_number_of_arguments = False
             try:
+                # e.__traceback__ is deliberately not bound to a local:
+                # Python auto-deletes `e` (and thus its traceback) at the
+                # end of this except clause, but a local we introduce
+                # ourselves isn't covered by that, and the traceback's
+                # tb_frame is this very frame, so binding it would form
+                # a frame<->traceback reference cycle that keeps this
+                # watcher alive until the next gc collection
                 _run_callback_is_top_frame = (
-                    e.__traceback__.tb_frame.f_code == self._run_callback.__code__
+                    e.__traceback__.tb_frame.f_code  # ty: ignore[unresolved-attribute]
+                    == self._run_callback.__code__
                 )
-                _no_lower_frames = e.__traceback__.tb_next is None
+                _no_lower_frames = (
+                    e.__traceback__.tb_next is None  # ty: ignore[unresolved-attribute]
+                )
                 wrong_number_of_arguments = (
                     _run_callback_is_top_frame and _no_lower_frames
                 )
@@ -469,7 +546,7 @@ class Watcher(Generic[T]):
             else:
                 raise
 
-    def get(self) -> Any:
+    def get(self) -> T | None:
         Dep.stack.append(self)
         try:
             value_or_coro = self.fn()
@@ -481,7 +558,7 @@ class Watcher(Generic[T]):
                     task = loop.create_task(value_or_coro)
                     self._tasks.add(task)
                     task.add_done_callback(self._tasks.discard)
-                    return
+                    return None
             if self.deep:
                 traverse(value_or_coro)
         finally:
@@ -511,10 +588,11 @@ class Watcher(Generic[T]):
 
     @property
     def fn_fqn(self) -> str:
-        return f"{self.fn.__module__}.{self.fn.__qualname__}"
+        fn = self.fn
+        return f"{getattr(fn, '__module__', None)}.{getattr(fn, '__qualname__', None)}"
 
 
-def weak(obj: Any, method: Callable):
+def weak(obj: Any, method: Callable[..., Any]) -> Callable[..., Any]:
     """
     Returns a wrapper for the given method that will only call the method if the
     given object is not garbage collected yet. It does so by using a weakref.ref
@@ -531,14 +609,14 @@ def weak(obj: Any, method: Callable):
         if iscoro:
 
             @wraps(method)
-            async def wrapped():
+            async def wrapped() -> Any:
                 if this := weak_obj():
                     return await method(this)
 
         else:
 
             @wraps(method)
-            def wrapped():
+            def wrapped() -> Any:
                 if this := weak_obj():
                     return method(this)
 
@@ -547,41 +625,41 @@ def weak(obj: Any, method: Callable):
         if iscoro:
 
             @wraps(method)
-            async def wrapped(new):
+            async def wrapped_new(new: Any) -> Any:
                 if this := weak_obj():
                     return await method(this, new)
 
         else:
 
             @wraps(method)
-            def wrapped(new):
+            def wrapped_new(new: Any) -> Any:
                 if this := weak_obj():
                     return method(this, new)
 
-        return wrapped
+        return wrapped_new
     elif nr_arguments == 3:
         if iscoro:
 
             @wraps(method)
-            async def wrapped(new, old):
+            async def wrapped_new_old(new: Any, old: Any) -> Any:
                 if this := weak_obj():
                     return await method(this, new, old)
 
         else:
 
             @wraps(method)
-            def wrapped(new, old):
+            def wrapped_new_old(new: Any, old: Any) -> Any:
                 if this := weak_obj():
                     return method(this, new, old)
 
-        return wrapped
+        return wrapped_new_old
     else:
         raise WrongNumberOfArgumentsError(
             "Please use 1, 2 or 3 arguments for callbacks"
         )
 
 
-def is_bound_method(fn: Callable):
+def is_bound_method(fn: Callable[..., Any]) -> TypeIs[MethodType]:
     """
     Returns whether the given function is a bound method.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.9"
 readme = "README.md"
 license = "MIT"
+classifiers = ["Typing :: Typed"]
 dependencies = []
 
 [project.urls]
@@ -22,8 +23,10 @@ dev = [
     "pytest-benchmark",
     "pytest-cov",
     "pytest-timeout",
+    "ty",
 ]
 ruff = ["ruff"]
+ty = ["ty"]
 qt = [
     "PySide6>=6.7,!=6.8.3",
     "pytest-qt",
@@ -63,6 +66,14 @@ select = [
 "bench/*" = ["F821"]
 # command line tool that reports through print
 "bench/compare_runs.py" = ["T201"]
+
+[tool.ty.src]
+include = ["observ"]
+
+[tool.ty.environment]
+# Match the oldest supported Python version (requires-python), so
+# that the type checker catches use of newer typing features
+python-version = "3.9"
 
 [tool.pytest.ini_options]
 # GC pauses during timed rounds are a major source of benchmark noise


### PR DESCRIPTION
Part 2 of 2 for #114 — closes #114. **Stacked on #184** (base is that PR's branch; once #184 merges this retargets to `master`). This PR is annotations and typing infrastructure only: the runtime tree is identical apart from the local rebinds/asserts noted below.

## Type checker: ty

Adds [ty](https://github.com/astral-sh/ty) (Astral's type checker, the modern alternative to mypy) to the dev toolchain and guards against drift:

* A dedicated **Typecheck job in CI** (added to `publish`'s `needs`), installing only the new `ty` dependency group.
* A **pre-commit hook** running `ty check`.
* `[tool.ty]` config in `pyproject.toml`, scoped to `observ/` with `python-version = "3.9"` to match `requires-python`.

On the current code ty reported 29 diagnostics; all are fixed here, including genuine annotation bugs: `_run_callback` returns a value but was annotated `-> None`, `Dep._subs` was typed `WeakSet` but initialized to `None`, and `Watcher.on_created`/`on_destroyed` should be `ClassVar`s.

## Items from #111/#114

* **PEP 604 unions** (`X | Y`) everywhere instead of `Union`/`Optional`. The `Watchable`/`WatchCallback` aliases live in a `TYPE_CHECKING` block so the `|` syntax never runs on Python 3.9; all annotation positions are covered by `from __future__ import annotations`.
* **The casts in `to_raw`** ([discussion](https://github.com/fork-tongue/observ/pull/111#discussion_r1392316931)) are genuinely required — the type system cannot know that rebuilding a container from its unproxied items preserves its type — and are now documented in place. In the hot `proxy()` path, `Any`-typed locals are used instead, since `typing.cast` is a real function call at runtime (verified with interleaved benchmark runs against master using `compare_runs.py`: no benchmark consistently regressed).
* **Watchable callables don't have to return anything**: `T` binds to `None` for effect-style functions; documented on the alias.

## Other typing improvements

* **`py.typed` marker (PEP 561)** shipped in the wheel plus the `Typing :: Typed` classifier, so downstream type checkers actually pick up the annotations.
* **`computed`** is typed with overloads returning a `Computed` protocol, making the `__watcher__` attribute part of the public type.
* **`is_bound_method`** is a `TypeIs` guard narrowing to `MethodType` (via `typing_extensions` under `TYPE_CHECKING` only — no runtime dependency).
* **`Scheduler`** grows a `SupportsCallSoon` protocol for the loop objects accepted by `register_asyncio`/`register_rendercanvas`, used by `init()` too.
* All internal signatures (traps, proxy_db, scheduler, proxy modules) fully annotated; the string-and-`noqa: F821` forward references are replaced with `TYPE_CHECKING` imports.
* `Proxy` deliberately keeps its class body annotation-free: class-level annotations would add an `__annotations__` attribute that leaks into the container proxies' surface (guarded by `test_wrapping_complete`); its slot types are inferred from `__init__`.

## Runtime-affecting details (deliberately minimal)

* `assert callback is not None` narrowing in `run_callback`/`_run_callback` (invariant already guaranteed by callers).
* `Any`-typed local rebinds in `proxy()` and the computed getter instead of `typing.cast`, to keep hot paths free of extra function calls.
* `_run_callback`'s traceback introspection **keeps its original control flow** (`try`/`except AttributeError`, `e.__traceback__` never bound to a local). Restructuring it into an explicit `is not None` check would require binding the traceback to a local — but that traceback's `tb_frame` *is* the current frame, so binding it creates a frame↔traceback reference cycle that Python's implicit `del e` doesn't protect against for a variable we introduce ourselves (it only auto-deletes `e` itself). That's real: I verified it with `gc` disabled — the bound-local version leaks the enclosing `Watcher` until the next incidental gc pass; the original doesn't. Two attribute accesses are narrowly suppressed instead (`# ty: ignore[unresolved-attribute]`, confirmed load-bearing by removing them and re-running `ty check`), since the type checker can't see that the `except AttributeError` branch already handles the `None` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC