### PR TITLE
Make the benchmark CI guard cheaper to trust and less prone to flakes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,12 @@ jobs:
       # Interleaving the runs and comparing the fastest PR run against
       # the slowest master run makes the guard robust against that noise
       # (see bench/compare_runs.py).
+      #
+      # Which side runs first alternates every round: a job that runs
+      # for several minutes can drift (CPU frequency scaling, thermal
+      # throttling, noisy neighbours), and always running master first
+      # would let that drift systematically favor (or disfavor) one
+      # side rather than average out.
       - name: Run benchmarks
         env:
           # Fixed hash seed: hash randomization moves dict/set benchmark
@@ -44,26 +50,78 @@ jobs:
         run: |
           git fetch origin master
 
-          for i in 1 2 3; do
-            # Run benchmarks with master code as baseline. Tolerate
-            # failures: the PR's benchmarks may exercise APIs that don't
-            # exist on master yet.
+          run_master() {
+            # Tolerate failures: the PR's benchmarks may exercise APIs
+            # that don't exist on master yet.
             git checkout origin/master -- observ/
-            uv run --no-sync pytest bench \
+            uv run --no-sync pytest bench "${PYTEST_ARGS[@]}" \
                 --benchmark-only \
-                --benchmark-save=master$i \
+                --benchmark-save="master$1" \
                 --benchmark-sort=mean || true
+          }
 
-            # Run benchmarks on PR code
+          run_branch() {
             git checkout HEAD -- observ/
-            uv run --no-sync pytest bench \
+            uv run --no-sync pytest bench "${PYTEST_ARGS[@]}" \
                 --benchmark-only \
-                --benchmark-save=branch$i \
+                --benchmark-save="branch$1" \
                 --benchmark-sort=mean
-          done
+          }
+
+          PYTEST_ARGS=()
+          run_master 1; run_branch 1
+          run_branch 2; run_master 2
+          run_master 3; run_branch 3
 
       - name: Compare benchmarks
+        id: compare
         run: |
+          uv run --no-sync python bench/compare_runs.py \
+              --baseline '.benchmarks/*/*_master?.json' \
+              --branch '.benchmarks/*/*_branch?.json' \
+              --threshold 0.10 \
+              --failed-out failed_benchmarks.txt \
+            || echo "initial_failed=1" >> "$GITHUB_OUTPUT"
+
+      # A regression flagged by only 3 rounds is still consistent with
+      # noise (see compare_runs.py's docstring). Rather than re-running
+      # the whole ~50-benchmark suite from scratch, collect 2 more
+      # rounds for just the benchmark(s) that were flagged -- cheap,
+      # since it's normally 1-3 out of ~50 -- and only fail the build
+      # if the regression survives that larger, still-targeted sample.
+      - name: Re-check flagged benchmarks with more targeted rounds
+        if: steps.compare.outputs.initial_failed == '1'
+        env:
+          PYTHONHASHSEED: "0"
+        run: |
+          names=()
+          while IFS= read -r name; do
+            names+=("$name")
+          done < failed_benchmarks.txt
+          echo "Initial 3 rounds flagged: ${names[*]}"
+          echo "Collecting 2 more rounds for just these before failing the build..."
+
+          run_master() {
+            git checkout origin/master -- observ/
+            uv run --no-sync pytest bench "${PYTEST_ARGS[@]}" \
+                --benchmark-only \
+                --benchmark-save="master$1" \
+                --benchmark-sort=mean || true
+          }
+
+          run_branch() {
+            git checkout HEAD -- observ/
+            uv run --no-sync pytest bench "${PYTEST_ARGS[@]}" \
+                --benchmark-only \
+                --benchmark-save="branch$1" \
+                --benchmark-sort=mean
+          }
+
+          k_expr=$(printf ' or %s' "${names[@]}")
+          PYTEST_ARGS=(-k "${k_expr# or }")
+          run_branch 4; run_master 4
+          run_master 5; run_branch 5
+
           uv run --no-sync python bench/compare_runs.py \
               --baseline '.benchmarks/*/*_master?.json' \
               --branch '.benchmarks/*/*_branch?.json' \

--- a/bench/compare_runs.py
+++ b/bench/compare_runs.py
@@ -121,6 +121,11 @@ def main(argv=None):
         default=0.10,
         help="max allowed consistent slowdown, as a fraction (default: 0.10)",
     )
+    parser.add_argument(
+        "--failed-out",
+        help="if given, write the names of failed benchmarks to this file, "
+        "one per line (for a caller to collect more rounds and retry)",
+    )
     args = parser.parse_args(argv)
 
     baseline_runs = load_runs(args.baseline)
@@ -159,6 +164,9 @@ def main(argv=None):
         )
         for name in failed:
             print(f"  {name}")
+        if args.failed_out:
+            with open(args.failed_out, "w") as fh:
+                fh.writelines(f"{name}\n" for name in failed)
         return 1
     print("\nNo benchmark consistently regressed beyond the threshold.")
     return 0


### PR DESCRIPTION
Prompted by #185 flaking twice in a row on the Benchmarks workflow, with two different, incoherent failure patterns each time (different benchmarks flagged, including code paths that PR never touched, swinging 10-30%). That pointed at runner-level noise rather than a real regression — confirmed by reproducing the exact gate methodology locally (passed) and an isolated microbenchmark of the actual hot path (branch same speed or faster than master).

Rather than keep manually re-running the workflow, this makes the guard cheaper to trust without spending more CI time on the common case:

## Changes

1. **Alternate which side runs first each round.** The workflow always ran master's 3 rounds before branch's 3 rounds, every iteration. A job that runs for several minutes can drift (CPU frequency scaling, thermal throttling, noisy neighbours on the runner) — always running the same side first lets that drift systematically bias the comparison instead of averaging out. Now the order alternates (master→branch, branch→master, master→branch), at zero extra cost.

2. **Only pay for extra rounds when the first pass is ambiguous.** `compare_runs.py` gets a new `--failed-out PATH` flag that writes flagged benchmark names to a file. When the initial 3-round comparison flags a regression, a new workflow step collects **2 more rounds filtered to just those benchmark(s)** via `pytest -k` (not the full ~50-benchmark suite), and only fails the build if the regression survives the larger, still-targeted sample.

Net effect: the no-regression case (the overwhelming majority of PRs) costs exactly what it costs today. A flaky single-benchmark blip now self-heals in a few extra seconds instead of requiring a full ~4.5-minute manual re-run of the whole suite. A genuine, consistent regression still fails the build — it now has to survive 5 rounds instead of 3.

Verified locally: the new `--failed-out` flag on a synthetic regression, the `-k` expression construction and quoting (bracketed parametrize names like `test_proxy_creation_dict[1k]` collect correctly), and a full end-to-end run of the alternated-order round logic against this repo's actual benchmarks (which reproduced the same kind of noisy variance seen in CI without a false failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC

---
_Generated by [Claude Code](https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC)_