### PR TITLE
Raise the benchmark guard threshold to 25%: it's a tripwire, not an instrument

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,9 +62,20 @@ jobs:
                 --benchmark-sort=mean
           done
 
+      # The 25% threshold makes this guard a tripwire for gross
+      # accidental regressions (an accidental copy in a hot path, an
+      # algorithmic slip), not a precision instrument. Even with the
+      # interleaved fastest-vs-slowest gate above, whole runs of
+      # identical code on hosted runners have been observed to differ
+      # by 10-30% (the same commit went fail/fail/pass across three
+      # attempts at a 10% threshold, flagging code paths its diff never
+      # touched). Gating below that noise floor just breeds re-run
+      # rituals. Regressions too small to trip this guard should be
+      # measured deliberately instead: repeated local runs of the bench
+      # suite on an idle machine.
       - name: Compare benchmarks
         run: |
           uv run --no-sync python bench/compare_runs.py \
               --baseline '.benchmarks/*/*_master?.json' \
               --branch '.benchmarks/*/*_branch?.json' \
-              --threshold 0.10
+              --threshold 0.25

--- a/bench/compare_runs.py
+++ b/bench/compare_runs.py
@@ -16,12 +16,19 @@ run by more than the threshold. A whole-process outlier on either side
 then can't produce a false positive, because the comparison always uses
 the branch's luckiest run against the baseline's unluckiest run.
 
+Even that gate has a noise floor: on shared CI runners, whole runs of
+identical code have been observed to differ by 10-30%. The threshold
+therefore has to sit above that floor, which makes this a tripwire for
+gross accidental regressions rather than a precision instrument --
+changes too small to trip it should be measured with deliberate
+repeated local runs instead.
+
 Usage:
 
     python bench/compare_runs.py \
         --baseline '.benchmarks/*/*_master?.json' \
         --branch '.benchmarks/*/*_branch?.json' \
-        --threshold 0.10
+        --threshold 0.25
 """
 
 import argparse
@@ -118,8 +125,8 @@ def main(argv=None):
     parser.add_argument(
         "--threshold",
         type=float,
-        default=0.10,
-        help="max allowed consistent slowdown, as a fraction (default: 0.10)",
+        default=0.25,
+        help="max allowed consistent slowdown, as a fraction (default: 0.25)",
     )
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Follow-up to the discussion on #186 (closed): instead of adding retry machinery, reposition the guard honestly.

## Why

The 10% threshold sat below the noise floor of GitHub-hosted runners. Even with the interleaved fastest-branch-vs-slowest-baseline gate, whole runs of identical code were observed to differ by 10–30%:

* On #185, the **same commit went fail → fail → pass across three attempts** of the Benchmarks workflow, with different benchmarks flagged each time.
* The failing runs flagged code paths the diff never touched — one untouched write-trap benchmark swung **+31.7%** within a single run set, another **−13%**.
* Reproducing the exact gate methodology locally on an idle machine passed cleanly, and an isolated GC-disabled microbenchmark of the flagged hot path showed the branch at parity or slightly faster.

A gate below the noise floor doesn't catch regressions — it breeds re-run-until-green rituals that erode trust in the check (and waste the CI minutes it was meant to justify).

## What this changes

* `--threshold 0.10` → `0.25` in the workflow, and the matching default in `compare_runs.py`.
* Comments in both places now state plainly what the guard is and isn't: a **tripwire for gross accidental regressions** (an accidental copy in a hot path, an algorithmic slip) — not a precision instrument. Changes too small to trip it should be measured deliberately with repeated local runs of the bench suite, which is both quieter and more sensitive than CI ever was at 10%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC

---
_Generated by [Claude Code](https://claude.ai/code/session_016fDq6fyKg6QscqyyN6CcwC)_