### PR TITLE
Filter plain leaf values out of the traverse stack at push time

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 from weakref import ref
 
 from .dep import Dep
-from .proxy import Proxy, proxy
+from .proxy import PLAIN_TYPES, Proxy, proxy
 from .proxy_db import proxy_db
 from .scheduler import scheduler
 
@@ -218,9 +218,16 @@ def traverse(obj: Any) -> None:
                 dep = proxy(current).__dep__
             dep.depend()
 
-        # Add children to stack
+        # Add children to stack. Plain-typed values are filtered out
+        # right here: they can never be a proxy or a traversable
+        # container, so pushing them just to discard them on the next
+        # pop would double the cost of scalar-heavy containers
         if current:
-            stack.extend((value, child_tracked) for value in val_iter)
+            stack.extend(
+                (value, child_tracked)
+                for value in val_iter
+                if type(value) not in PLAIN_TYPES
+            )
 
 
 # Every Watcher gets a unique ID which is used to


### PR DESCRIPTION
## What

`traverse()` pushed every child value onto the traversal stack, including scalar leaves (ints, strs, …), each costing a tuple allocation, a push, a pop, the `isinstance(current, Proxy)` check and the type dispatch — just to be discarded. Values whose type is in `PLAIN_TYPES` can never be a proxy or a traversable container, so they are now filtered out at push time.

## Why

`traverse()` is the deep-watch hot loop: it runs on every evaluation of a deep watcher. Most real-world reactive trees are scalar-heavy, so most stack traffic was pure overhead.

## Measurements

`bench/test_traverse.py` medians on this machine (`PYTHONHASHSEED=0`, single run each, so indicative):

| benchmark | master | branch |
|---|---|---|
| test_traverse_matrix | 374.0us | 83.1us |
| test_traverse_large_flat_list | 134.3us | 21.6us |
| test_traverse_mixed | 37.7us | 17.6us |
| test_traverse_shallow | 14.2us | 3.1us |
| test_traverse_list | 155.8us | 112.1us |
| test_traverse_deep | 63.5us | 54.3us |

`test_deep_watch_mutate_leaf` improves correspondingly (e.g. 1k: ~7.7ms → ~4.6ms).

## Verification

- `pytest tests`: 150 passed
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_