### PR TITLE
Bisect the scheduler queue in place instead of slicing it

### DIFF
--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -203,8 +203,7 @@ class Scheduler:
             # If already past its id, it will be run next immediately.
             # Last part of the queue should stay ordered, in order to
             # properly make use of bisect and avoid deadlocks
-            i = bisect(self._queue_indices[self.index + 1 :], watcher.id)
-            i += self.index + 1
+            i = bisect(self._queue_indices, watcher.id, self.index + 1)
             self._queue.insert(i, watcher)
             self._queue_indices.insert(i, watcher.id)
 


### PR DESCRIPTION
## What

When a watcher is queued while a flush is running, `Scheduler.queue` sliced the tail of `_queue_indices` just to bisect it, copying O(n) entries per mid-flush enqueue and then correcting the returned index by hand. `bisect` takes a `lo` bound that searches the same range in place and returns the absolute index directly.

## Why

The slice is an avoidable O(n) allocation on a path that can run many times within a single flush (every sync-triggered enqueue during callback execution). Measured ~10x faster for the bisect step on a 1000-entry queue; behavior is identical.

## Verification

- `pytest tests`: 150 passed (includes the scheduler ordering/deadlock tests in `tests/test_scheduler.py`)
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_