### PR TITLE
Cut per-call overhead in the proxy traps

### DIFF
--- a/observ/traps.py
+++ b/observ/traps.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial, wraps
-from operator import xor
 from typing import TYPE_CHECKING, Any
 
 from .dep import Dep
@@ -19,6 +18,22 @@ if TYPE_CHECKING:
     # given container type
     TrapFactory = Callable[[str, type], Trap]
 
+# Performance notes that apply to all trap factories below. Traps are
+# the per-read/per-write entry points of observ, so their call overhead
+# is felt in every interaction with a proxy:
+# - The Dep.stack list (a ClassVar that is only ever mutated, never
+#   reassigned) is bound to a closure variable, which is cheaper to
+#   load than a global plus an attribute
+# - Dep.depend() is inlined as dep_stack[-1].add_dep(dep), which saves
+#   a method call plus a second check of the stack per tracked read
+# - proxy() is called with positional arguments; keyword arguments
+#   make a call measurably slower
+# - Trap signatures only take **kwargs when a wrapped method actually
+#   accepts keyword arguments (only list.sort does; dict.update is
+#   handled explicitly), because **kwargs allocates a dict on every
+#   call. The wrapped plain containers raise TypeError for unexpected
+#   keyword arguments, and so do the traps
+
 
 class ReadonlyError(Exception):
     """
@@ -30,38 +45,46 @@ class ReadonlyError(Exception):
 
 def read_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
+    dep_stack = Dep.stack
 
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
-        if Dep.stack:
-            self.__dep__.depend()
-        value = fn(self.__target__, *args, **kwargs)
+    def trap(self: Proxy[Any], *args: Any) -> Any:
+        if dep_stack:
+            dep_stack[-1].add_dep(self.__dep__)
+        value = fn(self.__target__, *args)
         if self.__shallow__:
             return value
-        return proxy(value, readonly=self.__readonly__)
+        return proxy(value, self.__readonly__)
 
     return trap
+
+
+# The proxy function with the readonly flag pre-bound, for both flag
+# values, so that iterate_trap doesn't construct a partial per call
+_PROXY_PARTIAL = partial(proxy, readonly=False)
+_PROXY_PARTIAL_READONLY = partial(proxy, readonly=True)
 
 
 def iterate_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
     # Hoist the method check out of the trap
     is_items = method == "items"
+    dep_stack = Dep.stack
 
+    # The wrapped iterator methods (items, values, keys, __iter__,
+    # __reversed__) take no arguments at all
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
-        if Dep.stack:
-            self.__dep__.depend()
-        iterator = fn(self.__target__, *args, **kwargs)
+    def trap(self: Proxy[Any]) -> Any:
+        if dep_stack:
+            dep_stack[-1].add_dep(self.__dep__)
+        iterator = fn(self.__target__)
         if self.__shallow__:
             return iterator
+        readonly = self.__readonly__
         if is_items:
-            return (
-                (key, proxy(value, readonly=self.__readonly__))
-                for key, value in iterator
-            )
+            return ((key, proxy(value, readonly)) for key, value in iterator)
         else:
-            proxied = partial(proxy, readonly=self.__readonly__)
+            proxied = _PROXY_PARTIAL_READONLY if readonly else _PROXY_PARTIAL
             return map(proxied, iterator)
 
     return trap
@@ -69,15 +92,16 @@ def iterate_trap(method: str, obj_cls: type) -> Trap:
 
 def read_key_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
+    dep_stack = Dep.stack
 
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
-        if Dep.stack:
-            self.__dep__.keydep(args[0]).depend()
-        value = fn(self.__target__, *args, **kwargs)
+    def trap(self: Proxy[Any], key: Any, *args: Any) -> Any:
+        if dep_stack:
+            dep_stack[-1].add_dep(self.__dep__.keydep(key))
+        value = fn(self.__target__, key, *args)
         if self.__shallow__:
             return value
-        return proxy(value, readonly=self.__readonly__)
+        return proxy(value, self.__readonly__)
 
     return trap
 
@@ -115,27 +139,29 @@ def write_trap(method: str, obj_cls: type) -> Trap:
 def write_dict_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
+    # The signature mirrors dict.update: at most one positional-only
+    # argument (a mapping or an iterable of key/value pairs), plus
+    # arbitrary keyword arguments
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
+    def trap(self: Proxy[Any], positional: Any = _MISSING, /, **kwargs: Any) -> Any:
         target = self.__target__
-        # Normalize the arguments (an optional mapping or iterable of
-        # key/value pairs, plus optional keyword arguments) into a
-        # single dict, so that only the incoming keys have to be
-        # diffed for changes. This also makes sure that an iterable
-        # argument is not consumed twice
-        if args:
-            incoming = dict(args[0])
+        target_get = target.get
+        # Normalize the arguments into a single dict, so that only the
+        # incoming keys have to be diffed for changes. This also makes
+        # sure that an iterable argument is not consumed twice
+        if positional is not _MISSING:
+            incoming = dict(positional)
             if kwargs:
                 incoming.update(kwargs)
         else:
             incoming = kwargs
-        old_values = {key: target.get(key, _MISSING) for key in incoming}
+        old_values = {key: target_get(key, _MISSING) for key in incoming}
         retval = fn(target, incoming)
         dep = self.__dep__
         keydeps = dep.keydeps if dep.keydeps is not None else _NO_KEYDEPS
         change_detected = False
         for key, old_value in old_values.items():
-            if old_value is not target.get(key, _MISSING):
+            if old_value is not target_get(key, _MISSING):
                 keydep = keydeps.get(key)
                 if keydep is not None:
                     keydep.notify()
@@ -151,10 +177,10 @@ def write_len_compare_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
+    def trap(self: Proxy[Any], *args: Any) -> Any:
         target = self.__target__
         old_len = len(target)
-        retval = fn(target, *args, **kwargs)
+        retval = fn(target, *args)
         if len(target) != old_len:
             self.__dep__.notify()
         return retval
@@ -165,6 +191,8 @@ def write_len_compare_trap(method: str, obj_cls: type) -> Trap:
 def write_copy_compare_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
+    # list.sort takes keyword arguments (key and reverse), so this is
+    # the one write trap that must accept **kwargs
     @wraps(fn)
     def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
         target = self.__target__
@@ -212,11 +240,10 @@ def write_key_trap(method: str, obj_cls: type) -> Trap:
     is_setdefault = method == "setdefault"
 
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
+    def trap(self: Proxy[Any], key: Any, *args: Any) -> Any:
         target = self.__target__
-        key = args[0]
         old_value = getitem_fn(target, key, _MISSING)
-        retval = fn(target, *args, **kwargs)
+        retval = fn(target, key, *args)
         if is_setdefault and not self.__shallow__:
             # This method is only available when readonly is false
             retval = proxy(retval)
@@ -227,7 +254,7 @@ def write_key_trap(method: str, obj_cls: type) -> Trap:
         # (e.g. PySide6's ItemFlags), see test_use_weird_types_as_value
         if old_value is not new_value and (
             old_value is _MISSING
-            or xor(old_value is None, new_value is None)
+            or (old_value is None) != (new_value is None)
             or old_value != new_value
         ):
             dep = self.__dep__
@@ -245,9 +272,10 @@ def write_key_trap(method: str, obj_cls: type) -> Trap:
 def delete_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
+    # The wrapped deleter methods (clear, popitem) take no arguments
     @wraps(fn)
-    def trap(self: DictProxyBase, *args: Any, **kwargs: Any) -> Any:
-        retval = fn(self.__target__, *args, **kwargs)
+    def trap(self: DictProxyBase) -> Any:
+        retval = fn(self.__target__)
         dep = self.__dep__
         dep.notify()
         keydeps = dep.keydeps if dep.keydeps is not None else _NO_KEYDEPS
@@ -266,10 +294,9 @@ def delete_key_trap(method: str, obj_cls: type) -> Trap:
     fn = getattr(obj_cls, method)
 
     @wraps(fn)
-    def trap(self: Proxy[Any], *args: Any, **kwargs: Any) -> Any:
-        key = args[0]
+    def trap(self: Proxy[Any], key: Any, *args: Any) -> Any:
         key_existed = key in self.__target__
-        retval = fn(self.__target__, *args, **kwargs)
+        retval = fn(self.__target__, key, *args)
         if key_existed:
             dep = self.__dep__
             dep.notify()

--- a/tests/test_trap_signatures.py
+++ b/tests/test_trap_signatures.py
@@ -1,0 +1,205 @@
+"""
+Traps mirror the call conventions of the plain container methods they
+wrap: positional arguments are forwarded as-is, and keyword arguments
+are only accepted where the plain method accepts them (list.sort;
+dict.update takes arbitrary **kwargs). These tests pin down argument
+positioning and resolution through the traps, and check that calls a
+plain container rejects with a TypeError are also rejected on a proxy.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from observ import reactive, readonly, to_raw
+from observ.traps import ReadonlyError
+
+
+def test_dict_get_argument_positioning():
+    obj = reactive({"a": 1})
+
+    assert obj.get("a") == 1
+    assert obj.get("missing") is None
+    # The default is a positional argument, just like on a plain dict
+    assert obj.get("missing", "default") == "default"
+
+    # A nested default is run through proxy() like any other read
+    nested = obj.get("missing", {"deep": True})
+    assert nested["deep"] is True
+
+    # Plain dict.get accepts no keyword arguments; neither does the trap
+    with pytest.raises(TypeError):
+        {}.get("a", default=1)
+    with pytest.raises(TypeError):
+        obj.get("a", default=1)
+    # Calling get without arguments fails on both as well
+    with pytest.raises(TypeError):
+        {}.get()
+    with pytest.raises(TypeError):
+        obj.get()
+
+
+def test_dict_update_argument_resolution():
+    obj = reactive({"a": 1})
+    mock = Mock()
+    obj.__dep__.add_sub(mock)
+
+    # A mapping argument
+    obj.update({"b": 2})
+    assert obj["b"] == 2
+    mock.update.assert_called_once()
+
+    # An iterable of key/value pairs
+    mock.reset_mock()
+    obj.update([("c", 3)])
+    assert obj["c"] == 3
+    mock.update.assert_called_once()
+
+    # Keyword arguments only
+    mock.reset_mock()
+    obj.update(d=4)
+    assert obj["d"] == 4
+    mock.update.assert_called_once()
+
+    # A mapping combined with keyword arguments; the keyword argument
+    # wins for a duplicated key, just like on a plain dict
+    mock.reset_mock()
+    obj.update({"e": "positional", "f": 6}, e="keyword")
+    assert obj["e"] == "keyword"
+    assert obj["f"] == 6
+    mock.update.assert_called_once()
+
+    # More than one positional argument fails on both
+    with pytest.raises(TypeError):
+        {}.update({}, {})
+    with pytest.raises(TypeError):
+        obj.update({}, {})
+
+
+def test_list_sort_keyword_arguments():
+    obj = reactive([3, 1, 2])
+    mock = Mock()
+    obj.__dep__.add_sub(mock)
+
+    # list.sort is the one wrapped method that takes keyword arguments
+    obj.sort(key=lambda item: -item, reverse=True)
+    assert to_raw(obj) == [1, 2, 3]
+    mock.update.assert_called_once()
+
+    # sort accepts no positional arguments, on either side
+    with pytest.raises(TypeError):
+        [].sort(lambda item: item)
+    with pytest.raises(TypeError):
+        obj.sort(lambda item: item)
+
+
+def test_dict_setdefault_argument_positioning():
+    obj = reactive({"a": 1})
+    assert obj.setdefault("a", 99) == 1
+    assert obj.setdefault("b", 2) == 2
+    assert obj["b"] == 2
+
+    # The default for a missing key comes back proxied
+    nested = obj.setdefault("c", {"deep": True})
+    assert nested["deep"] is True
+    assert type(nested) is not dict
+
+    # setdefault without a default, like on a plain dict
+    assert obj.setdefault("d") is None
+
+    # Plain dict.setdefault accepts no keyword arguments
+    with pytest.raises(TypeError):
+        {}.setdefault("a", default=1)
+    with pytest.raises(TypeError):
+        obj.setdefault("a", default=1)
+
+
+def test_dict_pop_argument_positioning():
+    obj = reactive({"a": 1})
+    assert obj.pop("missing", "default") == "default"
+    assert obj.pop("a") == 1
+    with pytest.raises(KeyError):
+        obj.pop("a")
+
+    # Plain dict.pop accepts no keyword arguments
+    with pytest.raises(TypeError):
+        {}.pop("a", default=1)
+    with pytest.raises(TypeError):
+        obj.pop("a", default=1)
+
+
+def test_list_multi_positional_arguments():
+    obj = reactive([1, 2, 3, 2])
+
+    # index takes optional start/stop positionally
+    assert obj.index(2) == 1
+    assert obj.index(2, 2) == 3
+    assert obj.index(2, 2, 4) == 3
+
+    # pop with and without an index
+    assert obj.pop() == 2
+    assert obj.pop(0) == 1
+    assert to_raw(obj) == [2, 3]
+
+    # insert requires both arguments
+    with pytest.raises(TypeError):
+        [].insert(0)
+    with pytest.raises(TypeError):
+        obj.insert(0)
+
+
+def test_set_multi_positional_arguments():
+    obj = reactive({1, 2})
+
+    # These accept any number of positional arguments
+    assert obj.union({3}, [4]) == {1, 2, 3, 4}
+    assert obj.difference({1}, {2}) == set()
+    assert obj.issubset({1, 2, 3})
+
+    obj.update({3}, [4])
+    assert to_raw(obj) == {1, 2, 3, 4}
+
+
+def test_iterators_take_no_arguments():
+    obj = reactive({"a": 1})
+    # Plain dict iterator methods take no arguments; neither do the traps
+    with pytest.raises(TypeError):
+        {}.values("bogus")
+    with pytest.raises(TypeError):
+        obj.values("bogus")
+    with pytest.raises(TypeError):
+        {}.items("bogus")
+    with pytest.raises(TypeError):
+        obj.items("bogus")
+
+
+def test_unexpected_keyword_arguments_raise_typeerror():
+    """
+    Calls that a plain container rejects with a TypeError are also
+    rejected on a proxy.
+    """
+    plain_and_proxied = [
+        ({"a": 1}, lambda d: d.keys(x=1)),
+        ({"a": 1}, lambda d: d.popitem(x=1)),
+        ({"a": 1}, lambda d: d.__getitem__("a", x=1)),
+        ([1], lambda ls: ls.append(1, x=1)),
+        ([1], lambda ls: ls.count(1, x=1)),
+        ({1}, lambda s: s.add(1, x=1)),
+    ]
+    for target, call in plain_and_proxied:
+        with pytest.raises(TypeError):
+            call(target)
+        with pytest.raises(TypeError):
+            call(reactive(target))
+
+
+def test_readonly_writes_raise_regardless_of_arguments():
+    obj = readonly({"a": [1, 2]})
+    with pytest.raises(ReadonlyError):
+        obj.update({"b": 2})
+    with pytest.raises(ReadonlyError):
+        obj.update(b=2)
+    with pytest.raises(ReadonlyError):
+        obj.pop("a")
+    with pytest.raises(ReadonlyError):
+        obj["a"].sort(reverse=True)


### PR DESCRIPTION
## What

Traps are the per-read/per-write entry points of observ, so their call overhead is felt in every interaction with a proxy. This PR trims it:

- **Only take `**kwargs` where the wrapped method actually accepts keyword arguments** (`list.sort`; `dict.update` is handled explicitly) — `**kwargs` allocates a dict on every call. Iterator and deleter traps now take no arguments at all, matching the methods they wrap (`items`, `values`, `__iter__`, `clear`, `popitem`, …).
- **Call `proxy()` positionally** — keyword calls measured ~25% slower per call.
- **Inline `Dep.depend()`** as `dep_stack[-1].add_dep(self.__dep__)`, saving a method call plus a redundant stack check per tracked read, with `Dep.stack` bound to a closure variable instead of a global + attribute lookup.
- **Hoist the readonly-bound `partial(proxy, ...)` pair** out of `iterate_trap` instead of constructing a partial per iteration call (2.8x on a 100-item iteration).
- Replace `operator.xor` with an inline `!=` in `write_key_trap`; bind `target.get` once in `write_dict_trap`.

## Argument positioning, resolution and backward compatibility

The new `tests/test_trap_signatures.py` pins down the call conventions so the tightened signatures can't drift:

- positional defaults (`get(key, default)`, `pop(key, default)`, `setdefault(key, default)`, `list.pop(i)`, `index(x, start, stop)`, multi-arg set methods),
- keyword resolution where plain containers accept it (`list.sort(key=, reverse=)`, `dict.update(**kwargs)` and mapping+kwargs precedence),
- TypeError parity: calls a plain container rejects (keyword args to `get`/`setdefault`/`keys`/`append`/…, too many/few positionals) are also rejected on a proxy,
- readonly proxies still raise `ReadonlyError` for writes regardless of argument shape.

Two deliberate, strictly-more-compatible behavior notes:
- Bogus keyword arguments now raise `TypeError` at the trap instead of inside the wrapped C function — same exception type as a plain container raises, different message.
- The dict `update`/`__ior__` trap now mirrors `dict.update`'s signature exactly (one positional-only argument plus `**kwargs`). It used to **silently ignore** extra positional arguments that a plain dict rejects with a `TypeError`; the new test caught that divergence.

## Measurements

`bench/test_reads.py` medians (`PYTHONHASHSEED=0`, single run each, so indicative):

| benchmark | master | branch |
|---|---|---|
| read_dict_getitem[reactive] | 30.8us | 20.5us |
| read_list_getitem[reactive] | 28.8us | 21.2us |
| read_dict_getitem_tracked | 74.9us | 52.8us |
| read_list_iterate[reactive] | 217.3us | 183.7us |

## Verification

- `pytest tests`: 160 passed (10 new tests)
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_