### PR TITLE
Use a set difference to release stale deps in cleanup_deps

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -573,9 +573,11 @@ class Watcher(Generic[T]):
                 dep.add_sub(self)
 
     def cleanup_deps(self) -> None:
-        for dep in self._deps:
-            if dep not in self._new_deps:
-                dep.remove_sub(self)
+        # A C-level set difference beats a Python-level loop with a
+        # containment check per dep, and this runs after every watcher
+        # evaluation (where the difference is typically empty)
+        for dep in self._deps - self._new_deps:
+            dep.remove_sub(self)
         self._deps, self._new_deps = self._new_deps, self._deps
         self._new_deps.clear()
 


### PR DESCRIPTION
## What

`Watcher.cleanup_deps` looped over `self._deps` with a `not in self._new_deps` containment check per dep. A C-level set difference does the same hash lookups without interpreter overhead per iteration, and yields nothing at all in the steady state where the dep sets are unchanged.

## Why

`cleanup_deps` runs after **every** watcher evaluation (it's called from the `finally` of `Watcher.get`). Measured ~1.5x faster at 5 deps with identical sets (the common case).

## Verification

- `pytest tests`: 150 passed (includes the dep bookkeeping tests in `tests/test_deps.py` and lifecycle tests in `tests/test_references.py`)
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_