### PR TITLE
Read the argument count off the code object in weak()

### DIFF
--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -592,6 +592,31 @@ class Watcher(Generic[T]):
         return f"{getattr(fn, '__module__', None)}.{getattr(fn, '__qualname__', None)}"
 
 
+# Code flags that mark parameters the plain co_argcount doesn't count
+_CO_VAR_FLAGS = inspect.CO_VARARGS | inspect.CO_VARKEYWORDS
+
+
+def _number_of_arguments(method: Callable[..., Any]) -> int:
+    """
+    Returns the number of parameters that the given method accepts.
+    For a plain function whose parameters are all regular positional
+    ones, the count can be read straight off the code object, which is
+    ~100x cheaper than building an inspect.Signature. Anything else
+    (wrapped/decorated functions, *args/**kwargs, keyword-only
+    parameters) falls back to inspect.signature, which knows how to
+    resolve those the same way this function's callers used to
+    """
+    code = getattr(method, "__code__", None)
+    if (
+        code is not None
+        and not hasattr(method, "__wrapped__")
+        and not code.co_flags & _CO_VAR_FLAGS
+        and code.co_kwonlyargcount == 0
+    ):
+        return code.co_argcount
+    return len(inspect.signature(method).parameters)
+
+
 def weak(obj: Any, method: Callable[..., Any]) -> Callable[..., Any]:
     """
     Returns a wrapper for the given method that will only call the method if the
@@ -601,9 +626,8 @@ def weak(obj: Any, method: Callable[..., Any]) -> Callable[..., Any]:
     """
     weak_obj = ref(obj)
 
-    sig = inspect.signature(method)
     iscoro = inspect.iscoroutinefunction(method)
-    nr_arguments = len(sig.parameters)
+    nr_arguments = _number_of_arguments(method)
 
     if nr_arguments == 1:
         if iscoro:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -107,3 +107,54 @@ def test_check_nr_arguments_of_weak_callback():
             sync=True,
             deep=True,
         )
+
+
+def test_weak_callback_decorated_method():
+    """
+    A decorated bound-method callback resolves its number of arguments
+    through the decorator's wrapper (this exercises the
+    inspect.signature fallback of the fast argument-count path).
+    """
+    from functools import wraps
+
+    calls = []
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    class Counter:
+        @decorator
+        def cb(self, new):
+            calls.append(new)
+
+    counter = Counter()
+    state = reactive({"count": 0})
+    counter.watcher = watch(lambda: state["count"], counter.cb, sync=True)
+
+    state["count"] = 1
+
+    assert calls == [1]
+
+
+def test_weak_callback_star_args_method():
+    """
+    A bound-method callback that takes *args counts as accepting a
+    single (new) argument, like inspect.signature reports it.
+    """
+    calls = []
+
+    class Counter:
+        def cb(self, *args):
+            calls.append(args)
+
+    counter = Counter()
+    state = reactive({"count": 0})
+    counter.watcher = watch(lambda: state["count"], counter.cb, sync=True)
+
+    state["count"] = 1
+
+    assert calls == [(1,)]


### PR DESCRIPTION
## What

`weak()` built an `inspect.Signature` just to count a bound method's parameters. That costs ~7µs and runs on every `Watcher`/`watch()` creation that has a bound-method fn or callback. For a plain function whose parameters are all regular positional ones, the same count can be read straight off the code object (`__code__.co_argcount`), ~100x cheaper.

The fast path only applies when it's guaranteed to agree with `inspect.signature`: no `__wrapped__` (decorated methods), no `*args`/`**kwargs` (`co_flags`), no keyword-only parameters. Everything else falls back to `inspect.signature`, preserving the previous behavior exactly.

## Tests

Existing tests already cover 1/2/3-argument bound-method callbacks and the too-many-arguments error. New tests in `tests/test_references.py` cover the fallback path:

- a `functools.wraps`-decorated bound-method callback (argument count resolved through the wrapper),
- a `*args` bound-method callback (counts as a single `new` argument, as `inspect.signature` reports it).

## Measurements

`watch()` with a bound-method fn and a bound-method callback: **32.9µs → 12.1µs** per creation (20k reps, this machine).

## Verification

- `pytest tests`: 152 passed (2 new tests)
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_