### PR TITLE
Count flush cycles with a single dict read and write

### DIFF
--- a/observ/scheduler.py
+++ b/observ/scheduler.py
@@ -167,8 +167,11 @@ class Scheduler:
             watcher.run()
 
             if self.detect_cycles:
-                self.circular[watcher.id] += 1
-                if self.circular[watcher.id] > 100:
+                # A single read-increment-write instead of the three
+                # dict operations of += followed by a re-read
+                runs = self.circular[watcher.id] + 1
+                self.circular[watcher.id] = runs
+                if runs > 100:
                     raise RecursionError(
                         "Infinite update loop detected in watched"
                         f" expression {watcher.fn_fqn}"


### PR DESCRIPTION
## What

The cycle detector in `Scheduler.flush` did three dict operations per flushed watcher: a read and a write for `self.circular[watcher.id] += 1`, then a re-read for the `> 100` check. Holding the incremented count in a local halves that.

## Why

Small, but it runs once per watcher per flush whenever cycle detection is on (the default). No behavior change.

## Verification

- `pytest tests`: 150 passed (includes the infinite-update-loop detection test)
- `ruff check` and `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyALuqgF1ZZ3Lj88FzwGVc)_