### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "observ"
-version = "0.19.0"
+version = "1.0.0"
 description = "Reactive state management for Python"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },


### PR DESCRIPTION
Bumps the version to **1.0.0** — observ's first stable release.

## What's in it since v0.19.0

**New features**
- `trigger_ref()` — force-notify the watchers of a proxy, mirroring Vue's `triggerRef` (#188, closes #123).
- Fully typed: modern type hints throughout, a `py.typed` marker, and `ty` type-checking enforced in CI (#185, #184, closes #114).

**Correctness**
- observ is now guaranteed — and tested — to create no reference cycles (#189). `proxy_db` lifetimes are managed by reference counting instead of a `gc` hook, so cleanup is deterministic and no longer relies on the garbage collector (#177).

**Docs & tooling**
- New MkDocs documentation site on GitHub Pages (#176), with an Internals section (#179) and a rewritten README (#180).
- Modernized CI workflows (#182) and a more robust benchmark guard (#181, #187).

## Performance

The headline of this release. A cluster of changes to the traversal, trap, and proxy-creation hot paths adds up to large wins across the board — deep-watch traversal in particular is up to **~85% faster**.

Numbers below are median times from `pytest-benchmark`, each version run twice and averaged, on an Apple M1 (CPython 3.14). Lower is better; negative change = faster.

### Deep-watch traversal (the biggest wins)

Filtering plain leaf values out of the traverse stack at push time and traversing raw targets directly (#190), on top of earlier traverse work.

| benchmark | v0.19.0 (µs) | v1.0.0 (µs) | change |
|---|--:|--:|--:|
| `test_traverse_large_flat_list` | 102.52 | 15.98 | **-84%** |
| `test_traverse_stress_large_shallow` | 105.71 | 18.50 | **-82%** |
| `test_traverse_matrix` | 270.56 | 56.19 | **-79%** |
| `test_traverse_shallow` | 11.04 | 2.42 | **-78%** |
| `test_traverse_stress_large_mixed` | 102.65 | 43.17 | **-58%** |
| `test_traverse_mixed` | 27.19 | 12.44 | **-54%** |
| `test_traverse_list` | 108.50 | 78.08 | **-28%** |
| `test_traverse_deep` | 45.06 | 38.10 | **-15%** |
| `test_traverse_wide` | 488.46 | 417.15 | **-15%** |
| Overall | | | **-55%** |

### Reactive writes

Lower per-operation trap overhead (#192).

| benchmark | v0.19.0 (µs) | v1.0.0 (µs) | change |
|---|--:|--:|--:|
| `test_write_dict_new_key[1k]` | 0.77 | 0.44 | **-43%** |
| `test_write_list_append[1k]` | 0.59 | 0.34 | **-43%** |
| `test_write_dict_setitem[1k]` | 0.88 | 0.57 | **-36%** |
| `test_write_list_setitem[1k]` | 0.54 | 0.35 | **-36%** |
| `test_write_set_add[1k]` | 0.62 | 0.40 | **-35%** |
| `test_write_dict_update[1k]` | 1.22 | 0.93 | **-24%** |
| Overall | | | **-31%** |

### Proxy creation

Proxies constructed with positional flags instead of keyword lookups (#193).

| benchmark | v0.19.0 (µs) | v1.0.0 (µs) | change |
|---|--:|--:|--:|
| `test_proxy_creation_dict[10]` | 9.91 | 4.80 | **-52%** |
| `test_proxy_creation_dict[100k]` | 16.97 | 8.29 | **-51%** |
| `test_proxy_creation_dict[1k]` | 9.68 | 5.07 | **-48%** |
| Overall | | | **-50%** |

### Reactive reads

| benchmark | v0.19.0 (µs) | v1.0.0 (µs) | change |
|---|--:|--:|--:|
| `test_read_dict_getitem_tracked` | 49.27 | 37.83 | **-23%** |
| `test_read_dict_getitem[reactive]` | 24.04 | 18.87 | **-21%** |
| `test_read_list_getitem[reactive]` | 22.38 | 19.69 | **-12%** |
| Overall | | | **-19%** |

### End-to-end (build + watch + mutate)

Whole-workflow benchmarks, so they fold the wins above together.

| benchmark | v0.19.0 (µs) | v1.0.0 (µs) | change |
|---|--:|--:|--:|
| `test_dict_plain_vs_reactive[reactive]` | 51,777.29 | 27,448.65 | **-47%** |
| `test_list_plain_vs_reactive[reactive]` | 38,708.31 | 21,608.22 | **-44%** |
| `test_deep_watch_mutate_leaf[1k]` | 4,571.75 | 2,609.08 | **-43%** |
| `test_set_plain_vs_reactive[reactive]` | 39,850.35 | 24,171.75 | **-39%** |
| `test_notify_watchers[1k]` | 1,982.15 | 1,839.74 | **-7%** |
| Overall | | | **-37%** |

Plain (non-reactive) baselines are unchanged, as expected (all within ±2% noise).

### One regression, called out honestly

`test_watcher_creation` went from ~2.6 µs to ~3.4 µs (**+30%**), consistent across both runs. This is a one-time cost paid when a `Watcher` is constructed, traded for the much cheaper notification and traversal that every watcher pays repeatedly afterwards. Net effect on any realistic workload is strongly positive — see the end-to-end numbers above.