### PR TITLE
Bump minimum Python to 3.13 and modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux py39
-            pyversion: "3.9"
-          - name: Linux py310
-            pyversion: "3.10"
-          - name: Linux py311
-            pyversion: "3.11"
-          - name: Linux py312
-            pyversion: "3.12"
           - name: Linux py313
             pyversion: "3.13"
           - name: Linux py314

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 * **Automatic dependency tracking** — computed state knows exactly what it depends on and lazily re-evaluates only when needed.
 * **React to any change** — watch plain state or computed state and build unidirectional data flow: state changes drive view changes, input events drive state changes.
-* **Zero dependencies, framework agnostic** — a pure Python library (≥ 3.9) that plugs into any event loop: asyncio, Qt, or your own.
+* **Zero dependencies, framework agnostic** — a pure Python library (≥ 3.13) that plugs into any event loop: asyncio, Qt, or your own.
 * **Fully typed** — a [PEP 561](https://peps.python.org/pep-0561/) typed package, checked with [ty](https://github.com/astral-sh/ty) in CI.
 
 ## Quick start

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Observ is published on [PyPI](https://pypi.org/project/observ/) and has **no dependencies**. It supports Python 3.9 and up.
+Observ is published on [PyPI](https://pypi.org/project/observ/) and has **no dependencies**. It supports Python 3.13 and up.
 
 === "uv"
 

--- a/docs/guide/scheduling.md
+++ b/docs/guide/scheduling.md
@@ -21,7 +21,7 @@ You can also pass a specific loop: `scheduler.register_asyncio(loop)`.
 
 !!! tip "Eager task factory"
 
-    On Python 3.12+, observ's `loop_factory()` helper creates a new event loop with the [eager task factory](https://docs.python.org/3/library/asyncio-task.html#asyncio.eager_task_factory) enabled, which reduces the latency of the async callbacks and watched functions that observ schedules as tasks:
+    observ's `loop_factory()` helper creates a new event loop with the [eager task factory](https://docs.python.org/3/library/asyncio-task.html#asyncio.eager_task_factory) enabled, which reduces the latency of the async callbacks and watched functions that observ schedules as tasks:
 
     ```python
     import asyncio

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Observ 👁
 
-Observ is a Python port of [Vue.js](https://vuejs.org/)' [computed properties and watchers](https://vuejs.org/guide/essentials/reactivity-fundamentals.html). It is event loop/framework agnostic and has no dependencies, so it can be used in any project targeting Python >= 3.9.
+Observ is a Python port of [Vue.js](https://vuejs.org/)' [computed properties and watchers](https://vuejs.org/guide/essentials/reactivity-fundamentals.html). It is event loop/framework agnostic and has no dependencies, so it can be used in any project targeting Python >= 3.13.
 
 Observ provides two benefits for stateful applications:
 

--- a/observ/init.py
+++ b/observ/init.py
@@ -37,11 +37,9 @@ def init(
 def loop_factory() -> asyncio.AbstractEventLoop:
     """
     Creates a new asyncio event loop with the eager task factory
-    enabled (Python 3.12+), which reduces the latency of the tasks
-    that observ schedules for async functions and callbacks.
+    enabled, which reduces the latency of the tasks that observ
+    schedules for async functions and callbacks.
     """
     loop = asyncio.new_event_loop()
-    eager_task_factory = getattr(asyncio, "eager_task_factory", None)
-    if eager_task_factory is not None:
-        loop.set_task_factory(eager_task_factory)
+    loop.set_task_factory(asyncio.eager_task_factory)
     return loop

--- a/observ/proxy.py
+++ b/observ/proxy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from .proxy_db import proxy_db
 
@@ -10,10 +10,8 @@ if TYPE_CHECKING:
 
     from .proxy_db import TargetDep
 
-T = TypeVar("T")
 
-
-class Proxy(Generic[T]):
+class Proxy[T]:
     """
     Proxy for an object/target.
 
@@ -64,7 +62,7 @@ TYPE_LOOKUP: dict[type, tuple[type[Proxy[Any]], type[Proxy[Any]]]] = {}
 PLAIN_TYPES: frozenset[type] = frozenset({type(None), bool, int, float, str, bytes})
 
 
-def proxy(target: T, readonly: bool = False, shallow: bool = False) -> T:
+def proxy[T](target: T, readonly: bool = False, shallow: bool = False) -> T:
     """
     Returns a Proxy for the given object. If a proxy for the given
     configuration already exists, it will return that instead of
@@ -123,14 +121,13 @@ def proxy(target: T, readonly: bool = False, shallow: bool = False) -> T:
 
 
 if TYPE_CHECKING:
-    # Only used for typing: at runtime a Ref is a plain (proxied) dict.
-    # Defined here (instead of unconditionally) because a generic
-    # TypedDict requires Python 3.11
-    class Ref(TypedDict, Generic[T]):
+    # Only used for typing: at runtime a Ref is a plain (proxied) dict,
+    # so it is kept behind TYPE_CHECKING and never constructed.
+    class Ref[T](TypedDict):
         value: T
 
 
-def ref(target: T) -> Ref[T]:
+def ref[T](target: T) -> Ref[T]:
     """
     Returns a reactive dict with a single 'value' key, set to the
     given target. Useful for making a single (plain) value reactive.
@@ -141,7 +138,7 @@ def ref(target: T) -> Ref[T]:
 reactive = proxy
 
 
-def readonly(target: T) -> T:
+def readonly[T](target: T) -> T:
     """
     Returns a readonly proxy for the given target: reads are tracked,
     but any write raises a ReadonlyError.
@@ -149,7 +146,7 @@ def readonly(target: T) -> T:
     return proxy(target, readonly=True)
 
 
-def shallow_reactive(target: T) -> T:
+def shallow_reactive[T](target: T) -> T:
     """
     Returns a shallow proxy for the given target: only the first level
     of the target is made reactive, nested values are returned raw.
@@ -157,14 +154,14 @@ def shallow_reactive(target: T) -> T:
     return proxy(target, shallow=True)
 
 
-def shallow_readonly(target: T) -> T:
+def shallow_readonly[T](target: T) -> T:
     """
     Combination of `shallow_reactive` and `readonly`.
     """
     return proxy(target, readonly=True, shallow=True)
 
 
-def trigger_ref(target: Proxy[T] | T) -> None:
+def trigger_ref[T](target: Proxy[T] | T) -> None:
     """
     Force-notify the watchers that depend on the given proxy, as if
     its first level was written to. This is typically used together
@@ -192,7 +189,7 @@ def trigger_ref(target: Proxy[T] | T) -> None:
     dep.notify()
 
 
-def to_raw(target: Proxy[T] | T) -> T:
+def to_raw[T](target: Proxy[T] | T) -> T:
     """
     Returns a raw object from which any trace of proxy has been replaced
     with its wrapped target value.
@@ -201,7 +198,7 @@ def to_raw(target: Proxy[T] | T) -> T:
     # that rebuilding a container from its (recursively unproxied)
     # items yields a value of the same type as the original target
     if isinstance(target, Proxy):
-        return to_raw(target.__target__)
+        return cast(T, to_raw(target.__target__))
 
     if isinstance(target, list):
         return cast(T, [to_raw(t) for t in target])

--- a/observ/watcher.py
+++ b/observ/watcher.py
@@ -12,7 +12,7 @@ from collections import deque
 from collections.abc import Container
 from functools import wraps
 from itertools import count
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 from weakref import ref
 
 from .dep import Dep
@@ -20,24 +20,22 @@ from .proxy import PLAIN_TYPES, Proxy, proxy
 from .proxy_db import proxy_db
 from .scheduler import scheduler
 
-T = TypeVar("T")
-
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from types import MethodType
-    from typing import ClassVar, Protocol
-
-    from typing_extensions import TypeIs
+    from typing import ClassVar, Protocol, TypeIs
 
     # Something that can be watched: a function (which doesn't have to
     # return anything) or a coroutine function, or a proxy (or other
     # container of proxies), which implies deep watching
-    Watchable = Callable[[], T] | Callable[[], Awaitable[T]] | T
+    type Watchable[T] = Callable[[], T] | Callable[[], Awaitable[T]] | T
     # Callbacks may accept zero, one (new value) or two
     # (new and old value) arguments
-    WatchCallback = Callable[[], Any] | Callable[[T], Any] | Callable[[T, T], Any]
+    type WatchCallback[T] = (
+        Callable[[], Any] | Callable[[T], Any] | Callable[[T, T], Any]
+    )
 
-    class Computed(Protocol[T]):
+    class Computed[T](Protocol):
         """
         The cached getter returned by `computed`.
         """
@@ -47,7 +45,7 @@ if TYPE_CHECKING:
         def __call__(self) -> T: ...
 
 
-def watch(
+def watch[T](
     fn: Watchable[T],
     callback: WatchCallback[T] | None = None,
     sync: bool = False,
@@ -81,7 +79,7 @@ def watch(
     return watcher
 
 
-def watch_effect(
+def watch_effect[T](
     fn: Watchable[T],
     sync: bool = False,
     deep: bool = True,
@@ -95,14 +93,14 @@ def watch_effect(
 
 
 @overload
-def computed(_fn: Callable[[], T]) -> Computed[T]: ...
+def computed[T](_fn: Callable[[], T]) -> Computed[T]: ...
 
 
 @overload
-def computed(*, deep: bool = True) -> Callable[[Callable[[], T]], Computed[T]]: ...
+def computed[T](*, deep: bool = True) -> Callable[[Callable[[], T]], Computed[T]]: ...
 
 
-def computed(
+def computed[T](
     _fn: Callable[[], T] | None = None, *, deep: bool = True
 ) -> Computed[T] | Callable[[Callable[[], T]], Computed[T]]:
     """
@@ -245,7 +243,7 @@ class WrongNumberOfArgumentsError(TypeError):
     pass
 
 
-class Watcher(Generic[T]):
+class Watcher[T]:
     __slots__ = (
         "__weakref__",
         "_active",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },
     { name = "Berend Klein Haneveld", email = "berendkleinhaneveld@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 readme = "README.md"
 license = "MIT"
 classifiers = ["Typing :: Typed"]
@@ -73,7 +73,7 @@ include = ["observ"]
 [tool.ty.environment]
 # Match the oldest supported Python version (requires-python), so
 # that the type checker catches use of newer typing features
-python-version = "3.9"
+python-version = "3.13"
 
 [tool.pytest.ini_options]
 # GC pauses during timed rounds are a major source of benchmark noise

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -22,10 +22,6 @@ def plain_loop():
 
 
 def create_eager_loop():
-    # only python>=3.12
-    if not hasattr(asyncio, "eager_task_factory"):
-        pytest.skip()
-
     loop = create_plain_loop()
     loop.set_task_factory(asyncio.eager_task_factory)
     return loop

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -55,10 +55,12 @@ EXCLUDED = {
     "__shallow__",
     "__weakref__",
     "__dep__",
-    # exclude attributes added by typing.Generic
+    # exclude attributes added by generics (typing.Generic and the
+    # native PEP 695 type parameters on Proxy[T])
     "_is_protocol",
     "__orig_bases__",
     "__parameters__",
+    "__type_params__",
     # New in Python 3.13
     "__firstlineno__",
     "__static_attributes__",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 from observ import init, loop_factory, scheduler
 
@@ -19,16 +18,7 @@ def test_init_asyncio():
 
 def test_loop_factory():
     async def _coroutine():
-        if sys.version_info < (3, 10):
-            return asyncio.get_event_loop()
-        else:
-            return asyncio.get_running_loop()
+        return asyncio.get_running_loop()
 
-    if sys.version_info >= (3, 12):
-        actual_loop = asyncio.run(_coroutine(), loop_factory=loop_factory)
-    else:
-        loop = loop_factory()
-        actual_loop = loop.run_until_complete(_coroutine())
-
-    if hasattr(asyncio, "eager_task_factory"):
-        assert actual_loop.get_task_factory() is asyncio.eager_task_factory
+    actual_loop = asyncio.run(_coroutine(), loop_factory=loop_factory)
+    assert actual_loop.get_task_factory() is asyncio.eager_task_factory


### PR DESCRIPTION
## Summary

Raise the minimum supported Python version to **3.13** and apply the modernizations that unlocks across the package, tests, CI and docs.

## Version bump

- `pyproject.toml`: `requires-python = ">=3.13"`, and the `ty` environment `python-version` bumped to `3.13` (so the type checker keeps matching the oldest supported version).
- CI: dropped the `3.9`–`3.12` rows from the test matrix, keeping `3.13` and `3.14`.
- README + docs: updated the advertised minimum version.

## Source modernization (unlocked by requiring ≥ 3.12/3.13)

- **PEP 695 generics**: `Proxy` and `Watcher` now use the native type-parameter syntax (`class Proxy[T]:`), as do `proxy`/`ref`/`readonly`/`computed`/`watch`/`watch_effect`/`to_raw` and the `Watchable`/`WatchCallback` type aliases. This removes the module-level `TypeVar` and the `typing.Generic` bases. Runtime behaviour is unchanged.
- **`asyncio.eager_task_factory`**: `loop_factory()` drops the `getattr` guard — the attribute always exists now.
- **`TypeIs`**: imported from `typing` (added in 3.13) instead of `typing_extensions`.
- The `Ref` `TypedDict` no longer needs its "requires 3.11" note.

## Test cleanup

- Removed `sys.version_info` / `hasattr(asyncio, "eager_task_factory")` guards that are now always true (`test_init.py`, `test_asyncio.py`).
- Excluded `__type_params__` (added by the native PEP 695 generic) from the wrapping-completeness check in `test_collections.py`, alongside the existing `Generic` artifacts.

## Validation

On Python 3.13, all of the following pass locally:

- `ruff check .` and `ruff format --check .`
- `ty check`
- `pytest tests` — 218 passed, 1 xfailed
- `uv build` + `twine check` on the resulting wheel/sdist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGH6yjPx1mpY134qtk6rXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGH6yjPx1mpY134qtk6rXa)_